### PR TITLE
Bump to 10.4.0 and add LDAP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Jellyfin app for YunoHost
 Jellyfin Server
 
-**Shipped version:** 10.3.7
+**Shipped version:** 10.4.0
 
 - [Yunohost project](https://yunohost.org)
 - [Jellyfin website](https://github.com/jellyfin/jellyfin)

--- a/conf/LDAP-Auth.xml
+++ b/conf/LDAP-Auth.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<PluginConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <LdapServer>localhost</LdapServer>
+  <LdapBaseDn>ou=users,dc=yunohost,dc=org</LdapBaseDn>
+  <LdapPort>389</LdapPort>
+  <LdapSearchAttributes>uid, cn, mail, displayName</LdapSearchAttributes>
+  <LdapUsernameAttribute>uid</LdapUsernameAttribute>
+  <LdapSearchFilter>(objectClass=mailAccount)</LdapSearchFilter>
+  <LdapAdminFilter>(enabledService=JellyfinAdministrator)</LdapAdminFilter>
+  <LdapBindUser>cn=admin,dc=yunohost,dc=org</LdapBindUser>
+  <LdapBindPassword>__BINDPASSWORD__</LdapBindPassword>
+  <CreateUsersFromLdap>true</CreateUsersFromLdap>
+  <UseSsl>false</UseSsl>
+</PluginConfiguration>

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,7 +1,0 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/jellyfin_ynh/releases/download/10.3.7/jellyfin_10.3.7-1_amd64.deb
-SOURCE_SUM=8d50ddcf8a222d3bab2e3a51c4e8d824889edcb4e76e6df4dbfc68fccfd30420937a598e7d1e3c9832cace5aa038536a8d32dfc82d33d419f6d8b9d52880682e
-SOURCE_SUM_PRG=sha512sum
-SOURCE_FORMAT=deb
-SOURCE_IN_SUBDIR=false
-SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin.deb

--- a/conf/jellyfin-amd64.src
+++ b/conf/jellyfin-amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/jellyfin/jellyfin/releases/download/v10.4.0/jellyfin_10.4.0-1_debian-amd64.deb
-SOURCE_SUM=3088e1e9c2f502ca003c04a84474dc3a25f9ded7fb8faa5e6d51f1322e118a590c946315d76c8f0c592d030725fcf2f9cab2b1d4e1de83472407ba24fcbdf6ee
+SOURCE_URL=https://github.com/jellyfin/jellyfin/releases/download/v10.4.1/jellyfin_10.4.1-1_debian-amd64.deb
+SOURCE_SUM=11cf6fa418d9a060c89390361f0eb5628a277029457e99ddd39f30d6fa1e69d484a9a321e8000aec8c70d8327460999343065e1993782cb44b1ac3b4cede353d
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/jellyfin-amd64.src
+++ b/conf/jellyfin-amd64.src
@@ -1,0 +1,7 @@
+SOURCE_URL=https://github.com/jellyfin/jellyfin/releases/download/v10.4.0/jellyfin_10.4.0-1_debian-amd64.deb
+SOURCE_SUM=3088e1e9c2f502ca003c04a84474dc3a25f9ded7fb8faa5e6d51f1322e118a590c946315d76c8f0c592d030725fcf2f9cab2b1d4e1de83472407ba24fcbdf6ee
+SOURCE_SUM_PRG=sha512sum
+SOURCE_FORMAT=deb
+SOURCE_IN_SUBDIR=false
+SOURCE_EXTRACT=false
+SOURCE_FILENAME=jellyfin.deb

--- a/conf/jellyfin-arm64.src
+++ b/conf/jellyfin-arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/jellyfin/jellyfin/releases/download/v10.3.7/jellyfin_10.3.7-1_debian-arm64.deb
-SOURCE_SUM=b1cc9660e58b971eceda89a2166fbb3e203fec32f9f7546434effcb5587ffb54fe809fa630c1e3eff491ee63541e1ef538ae9d001a86a3521fe26960ffd93604
+SOURCE_URL=https://github.com/jellyfin/jellyfin/releases/download/v10.4.0/jellyfin_10.4.0-1_debian-arm64.deb
+SOURCE_SUM=7e0720719aa36febdc617fe01db4a5b834e771416b7325e6b935745520b537c18c7827868ed9381acc33c62d980704c2952804959cfa086400a7995ce4e08a4d
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/jellyfin-arm64.src
+++ b/conf/jellyfin-arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/jellyfin/jellyfin/releases/download/v10.4.0/jellyfin_10.4.0-1_debian-arm64.deb
-SOURCE_SUM=7e0720719aa36febdc617fe01db4a5b834e771416b7325e6b935745520b537c18c7827868ed9381acc33c62d980704c2952804959cfa086400a7995ce4e08a4d
+SOURCE_URL=https://github.com/jellyfin/jellyfin/releases/download/v10.4.1/jellyfin_10.4.1-1_debian-arm64.deb
+SOURCE_SUM=d9b35e384ebe3ebce3e587298c07cd83f29f4ba70434838c6fa03caee96a63d6d60ba94755ebd5e3686878b9c5b1f5f4b2f0108003b701e7ee56c809f892892a
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/jellyfin-ffmpeg-amd64.src
+++ b/conf/jellyfin-ffmpeg-amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/jellyfin_ynh/releases/download/10.3.7/jellyfin-ffmpeg_4.0.4-3-stretch_amd64.deb
-SOURCE_SUM=b3bad07eff89f825385a0424a6c7a53c010455fe1ffe7beca3fb8f27a9dd35cdf2b445e00e1b0b8ee1ffe40967a9ed87bb954bc6abdd1b1bf03229ef53615bae
+SOURCE_URL=https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v4.2.1-1/jellyfin-ffmpeg_4.2.1-1-stretch_amd64.deb
+SOURCE_SUM=ba51dcf84992a848ec0b19b428f458c32bf6338ce76ffec8e3c33f90b4ce7984256f40769a852670fa51645dfedf08e7e2daae30cf1bb366c3c203fc6f20f5ce
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/jellyfin-ffmpeg-arm64.src
+++ b/conf/jellyfin-ffmpeg-arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v4.0.4-3/jellyfin-ffmpeg_4.0.4-3-stretch_arm64.deb
-SOURCE_SUM=a98a760886de0a78d4a08e6ff0b141ac006fa68081cfb74ed4b07b56b56dc0e502f2f4cad7d5d2e6b54df7a4b959f6439ca628db02f156b0c262812688bc1eef
+SOURCE_URL=https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v4.2.1-1/jellyfin-ffmpeg_4.2.1-1-stretch_arm64.deb
+SOURCE_SUM=d5411aa905e71384aed09b05266ed8ec13831e839bfeb69b698bd06be7067e93263f4b165f237b58bd8ba41c12693279454a3fde08a086fa2f0da4e3f293d0a9
 SOURCE_SUM_PRG=sha512sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/jellyfin-plugin-ldapauth.src
+++ b/conf/jellyfin-plugin-ldapauth.src
@@ -1,0 +1,7 @@
+SOURCE_URL=https://github.com/jellyfin/jellyfin-plugin-ldapauth/releases/download/v4/jellyfin-plugin-ldapauth_4.0.zip
+SOURCE_SUM=dc6c27ca97f8cb6e398f9552e1ed263210376e005ee10d118bf19e77d6df6badda4fd61b5d9c3532df66f885ac38dc73b39e11dc4d9f10a40d0dddf5c89522f9
+SOURCE_SUM_PRG=sha512sum
+SOURCE_FORMAT=zip
+SOURCE_IN_SUBDIR=false
+SOURCE_EXTRACT=false
+SOURCE_FILENAME=jellyfin-plugin-ldapauth.zip

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Jellyfin package for YunoHost.",
         "fr": "Jellyfin pour YunoHost."
     },
-    "version": "10.4.0",
+    "version": "10.4.1",
     "url": "https://github.com/jellyfin/jellyfin",
     "license": "GPL-2.0",
     "maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,15 @@
                     "fr": "Est-ce un site public ?"
                 },
                 "default": "true"
+            },
+            
+            {
+                "name": "password",
+                "type": "password",
+                "ask": {
+                    "en": "Type LDAP admin password",
+                    "fr": "Saisissez le mot de passe de l'admin LDAP"
+                }
             }
         ]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Jellyfin package for YunoHost.",
         "fr": "Jellyfin pour YunoHost."
     },
-    "version": "10.3.7",
+    "version": "10.4.0",
     "url": "https://github.com/jellyfin/jellyfin",
     "license": "GPL-2.0",
     "maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -102,23 +102,22 @@ ynh_app_setting_set $app port $port
 #=================================================
 
 ynh_app_setting_set $app final_path $final_path
-# Download, check integrity, uncompress and patch the source from app.src
 
+# Download, check integrity, uncompress and patch the source from jellyfin-ffmpeg-[arch].src
 case `uname -m` in
     x86_64) ynh_setup_source "$final_path" "jellyfin-ffmpeg-amd64" ;;
     aarch64) ynh_setup_source "$final_path" "jellyfin-ffmpeg-arm64" ;;
     *) ynh_die "Unknown arch" ;;
 esac
 
-ynh_app_setting_set $app final_path $final_path
-# Download, check integrity, uncompress and patch the source from app.src
-
+# Download, check integrity, uncompress and patch the source from jellyfin-[arch].src
 case `uname -m` in
     x86_64) ynh_setup_source "$final_path" "jellyfin-amd64" ;;
     aarch64) ynh_setup_source "$final_path" "jellyfin-arm64" ;;
     *) ynh_die "Unknown arch" ;;
 esac
 
+# Download, check integrity, uncompress and patch the source from jellyfin-plugin-ldapauth.src
 ynh_setup_source "$final_path" "jellyfin-plugin-ldapauth"
 
 #==============================================
@@ -134,18 +133,11 @@ rm $final_path/*.deb
 #==============================================
 
 plugins_path=/var/lib/jellyfin/plugins
-plugins_conf_path=$plugins_path/configurations
-plugins_conf_file=$plugins_conf_path/LDAP-Auth.xml
 ldap_plugin_path="$plugins_path/LDAP Authentication"
 
 mkdir -p "$ldap_plugin_path"
 unzip $final_path/jellyfin-plugin-ldapauth.zip -d "$ldap_plugin_path"
 rm $final_path/*.zip
-
-mkdir -p "$plugins_conf_path"
-cp ../conf/LDAP-Auth.xml "$plugins_conf_file"
-ynh_replace_string --match_string="__BINDPASSWORD__" --replace_string="$password" --target_file="$plugins_conf_file"
-chown -R jellyfin:jellyfin "$plugins_path"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -164,9 +156,13 @@ ynh_system_user_create $app
 #=================================================
 # MODIFY A CONFIG FILE
 #=================================================
-#cp -a ../conf/onlyoffice-documentserver.conf /etc/onlyoffice/documentserver/nginx/onlyoffice-documentserver.conf
-#ynh_replace_string "__NEXTCLOUDDOMAIN__" "$nextcloud_domain" "/etc/loolwsd/loolwsd.xml"
-#ynh_replace_string "__PASSWORD__" "$password" "/etc/loolwsd/loolwsd.xml"
+plugins_conf_path=$plugins_path/configurations
+plugins_conf_file=$plugins_conf_path/LDAP-Auth.xml
+
+mkdir -p "$plugins_conf_path"
+cp ../conf/LDAP-Auth.xml "$plugins_conf_file"
+ynh_replace_string --match_string="__BINDPASSWORD__" --replace_string="$password" --target_file="$plugins_conf_file"
+chown -R jellyfin:jellyfin "$plugins_path"
 
 #=================================================
 # STORE THE CONFIG FILE CHECKSUM
@@ -177,7 +173,7 @@ ynh_system_user_create $app
 ### you can make a backup of this file before modifying it again if the admin had modified it.
 
 # Calculate and store the config file checksum into the app settings
-#ynh_store_file_checksum "/etc/onlyoffice/documentserver/nginx/onlyoffice-documentserver.conf"
+ynh_store_file_checksum "$plugins_conf_file"
 
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -28,6 +28,7 @@ ynh_abort_if_errors
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
 is_public=$YNH_APP_ARG_IS_PUBLIC
+password=$YNH_APP_ARG_PASSWORD
 
 ### If it's a multi-instance app, meaning it can be installed several times independently
 ### The id of the app as stated in the manifest is available as $YNH_APP_ID
@@ -118,6 +119,7 @@ case `uname -m` in
     *) ynh_die "Unknown arch" ;;
 esac
 
+ynh_setup_source "$final_path" "jellyfin-plugin-ldapauth"
 
 #==============================================
 # INSTALL JELLYFIN
@@ -126,6 +128,24 @@ esac
 dpkg --install $final_path/jellyfin-ffmpeg.deb
 dpkg --install $final_path/jellyfin.deb
 rm $final_path/*.deb
+
+#==============================================
+# INSTALL LDAP PLUGIN
+#==============================================
+
+plugins_path=/var/lib/jellyfin/plugins
+plugins_conf_path=$plugins_path/configurations
+plugins_conf_file=$plugins_conf_path/LDAP-Auth.xml
+ldap_plugin_path="$plugins_path/LDAP Authentication"
+
+mkdir -p "$ldap_plugin_path"
+unzip $final_path/jellyfin-plugin-ldapauth.zip -d "$ldap_plugin_path"
+rm $final_path/*.zip
+
+mkdir -p "$plugins_conf_path"
+cp ../conf/LDAP-Auth.xml "$plugins_conf_file"
+ynh_replace_string --match_string="__BINDPASSWORD__" --replace_string="$password" --target_file="$plugins_conf_file"
+chown -R jellyfin:jellyfin "$plugins_path"
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -113,7 +113,7 @@ ynh_app_setting_set $app final_path $final_path
 # Download, check integrity, uncompress and patch the source from app.src
 
 case `uname -m` in
-    x86_64) ynh_setup_source "$final_path" ;;
+    x86_64) ynh_setup_source "$final_path" "jellyfin-amd64" ;;
     aarch64) ynh_setup_source "$final_path" "jellyfin-arm64" ;;
     *) ynh_die "Unknown arch" ;;
 esac

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -10,22 +10,39 @@ final_path=/opt/yunohost/$app
 # Source YunoHost helpers
 source /usr/share/yunohost/helpers
 
-# Stop emby-server service
-systemctl stop emby-server
+# Stop jellyfin service
+systemctl stop jellyfin
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 
 ynh_app_setting_set $app final_path $final_path
-# Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source "$final_path"
+
+# Download, check integrity, uncompress and patch the source from jellyfin-ffmpeg-[arch].src
+case `uname -m` in
+    x86_64) ynh_setup_source "$final_path" "jellyfin-ffmpeg-amd64" ;;
+    aarch64) ynh_setup_source "$final_path" "jellyfin-ffmpeg-arm64" ;;
+    *) ynh_die "Unknown arch" ;;
+esac
+
+# Download, check integrity, uncompress and patch the source from jellyfin-[arch].src
+case `uname -m` in
+    x86_64) ynh_setup_source "$final_path" "jellyfin-amd64" ;;
+    aarch64) ynh_setup_source "$final_path" "jellyfin-arm64" ;;
+    *) ynh_die "Unknown arch" ;;
+esac
+
+# Download, check integrity, uncompress and patch the source from jellyfin-plugin-ldapauth.src
+ynh_setup_source "$final_path" "jellyfin-plugin-ldapauth"
 
 #==============================================
-# INSTALL PLEX
+# INSTALL JELLYFIN
 #==============================================
 
-dpkg --install $final_path/emby-server-deb*
+dpkg --install $final_path/jellyfin-ffmpeg.deb
+dpkg --install $final_path/jellyfin.deb
+rm $final_path/*.deb
 
 #=================================================
 # NGINX CONFIGURATION
@@ -51,6 +68,6 @@ dpkg --install $final_path/emby-server-deb*
 #  ynh_app_setting_set "$app" unprotected_uris "/"
 #fi
 
-# Start emby-server service
-systemctl start emby-server
+# Start jellyfin service
+systemctl start jellyfin
 


### PR DESCRIPTION
Install current latest Jellyfin (10.4.0), and add support for LDAP by installing the plugin.
At first boot, Jellyfin typically requires to create a new admin user. With the plugin already installed, one shall enter a valid user from LDAP without any password (this will be the default admin).

This is my first contribution to YunoHost, please feel free to give me any tip if something is wrong or could be improved.