### PR TITLE
Fix url for old versions

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,14 +1,12 @@
 # See here for more information
 # https://github.com/YunoHost/package_check#syntax-check_process-file
 
-# Move this file from check_process.default to check_process when you have filled it.
-
 ;; Test complet
 	; Manifest
-		domain="domain.tld"	(DOMAIN)
-		path="/path"	(PATH)
-		admin="john"	(USER)
-		is_public=1	(PUBLIC|public=1|private=0)
+		domain="domain.tld"
+		path="/path"
+		admin="john"
+		is_public=1
 		discovery=1
 	; Checks
 		pkg_linter=1
@@ -18,18 +16,6 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		# 10.6.4~ynh1
-		#upgrade=1	from_commit=dc5ab412fe599ce6d558c2f55fe53d2c21956c08
-		# 10.6.4~ynh2
-		#upgrade=1	from_commit=2aab8003d64ffabe65bd11ebe5933cfef519b061
-		# 10.6.4~ynh3
-		#upgrade=1	from_commit=5478712c0ca7683503bc1b50cfafe81ea508065e
-		# 10.7.0~ynh1
-		#upgrade=1	from_commit=63ab03ab79cc088a52b8a36fb4fdf5918bf0e14b
-                # 10.7.5~ynh1
-		#upgrade=1	from_commit=8ed403b30a8d3e61e2d3bf5bc8d3f4cae1ed80b6
-                # 10.7.6~ynh1
-		upgrade=1	from_commit=227b2cb8661b59ba391802637d0893976ffb6dd4
 		backup_restore=1
 		multi_instance=0
 		port_already_use=0
@@ -38,15 +24,5 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=dc5ab412fe599ce6d558c2f55fe53d2c21956c08
-		name=10.6.4~ynh1
-	; commit=2aab8003d64ffabe65bd11ebe5933cfef519b061
-		name=10.6.4~ynh2
-	; commit=5478712c0ca7683503bc1b50cfafe81ea508065e
-		name=10.6.4~ynh3
-	; commit=63ab03ab79cc088a52b8a36fb4fdf5918bf0e14b
-		name=10.7.0~ynh1
-	; commit=8ed403b30a8d3e61e2d3bf5bc8d3f4cae1ed80b6
-		name=10.7.5~ynh1
-	; commit=227b2cb8661b59ba391802637d0893976ffb6dd4
-		name=10.7.6~ynh1
+#	; commit=
+#		name=

--- a/conf/ldap.src
+++ b/conf/ldap.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_14.0.0.0.zip
-SOURCE_SUM=7e09c87b698b3315357139468ec601b1395b2e88cb940c20d3e716f9bf48a37c
+SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_12.0.0.0.zip
+SOURCE_SUM=e3ef05fdb0cce145504a34595aefe568e47964e981017d9ccb87f39e58fff861
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/ldap.src
+++ b/conf/ldap.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_12.0.0.0.zip
-SOURCE_SUM=e3ef05fdb0cce145504a34595aefe568e47964e981017d9ccb87f39e58fff861
+SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_14.0.0.0.zip
+SOURCE_SUM=7e09c87b698b3315357139468ec601b1395b2e88cb940c20d3e716f9bf48a37c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/logging.json
+++ b/conf/logging.json
@@ -1,0 +1,38 @@
+{
+    "Serilog": {
+        "MinimumLevel": {
+            "Default": "Error",
+            "Override": {
+                "Microsoft": "Warning",
+                "System": "Warning"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "outputTemplate": "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
+                }
+            },
+            {
+                "Name": "Async",
+                "Args": {
+                    "configure": [
+                        {
+                            "Name": "File",
+                            "Args": {
+                                "path": "%JELLYFIN_LOG_DIR%//log_.log",
+                                "rollingInterval": "Day",
+                                "retainedFileCountLimit": 3,
+                                "rollOnFileSizeLimit": true,
+                                "fileSizeLimitBytes": 100000000,
+                                "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message}{NewLine}{Exception}"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "Enrich": [ "FromLogContext", "WithThreadId" ]
+    }
+}

--- a/conf/network.xml
+++ b/conf/network.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NetworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <RequireHttps>false</RequireHttps>
+  <CertificatePath />
+  <CertificatePassword />
+  <BaseUrl>__PATH__</BaseUrl>
+  <PublicHttpsPort>8920</PublicHttpsPort>
+  <HttpServerPortNumber>__PORT__</HttpServerPortNumber>
+  <HttpsPortNumber>8920</HttpsPortNumber>
+  <EnableHttps>false</EnableHttps>
+  <PublicPort>__PORT__</PublicPort>
+  <UPnPCreateHttpPortMap>false</UPnPCreateHttpPortMap>
+  <UDPPortRange />
+  <EnableIPV6>true</EnableIPV6>
+  <EnableIPV4>true</EnableIPV4>
+  <EnableSSDPTracing>false</EnableSSDPTracing>
+  <SSDPTracingFilter />
+  <UDPSendCount>2</UDPSendCount>
+  <UDPSendDelay>100</UDPSendDelay>
+  <IgnoreVirtualInterfaces>true</IgnoreVirtualInterfaces>
+  <VirtualInterfaceNames>vEthernet*</VirtualInterfaceNames>
+  <GatewayMonitorPeriod>60</GatewayMonitorPeriod>
+  <TrustAllIP6Interfaces>false</TrustAllIP6Interfaces>
+  <HDHomerunPortRange />
+  <PublishedServerUriBySubnet />
+  <AutoDiscoveryTracing>false</AutoDiscoveryTracing>
+  <AutoDiscovery>true</AutoDiscovery>
+  <RemoteIPFilter />
+  <IsRemoteIPFilterBlacklist>false</IsRemoteIPFilterBlacklist>
+  <EnableUPnP>true</EnableUPnP>
+  <EnableRemoteAccess>true</EnableRemoteAccess>
+  <LocalNetworkSubnets />
+  <LocalNetworkAddresses />
+  <KnownProxies />
+</NetworkConfiguration>

--- a/conf/system.xml
+++ b/conf/system.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ServerConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <LogFileRetentionDays>3</LogFileRetentionDays>
+  <IsStartupWizardCompleted>true</IsStartupWizardCompleted>
+  <EnableUPnP>true</EnableUPnP>
+  <EnableMetrics>false</EnableMetrics>
+  <PublicPort>__PORT__</PublicPort>
+  <UPnPCreateHttpPortMap>false</UPnPCreateHttpPortMap>
+  <UDPPortRange />
+  <EnableIPV6>true</EnableIPV6>
+  <EnableIPV4>true</EnableIPV4>
+  <EnableSSDPTracing>false</EnableSSDPTracing>
+  <SSDPTracingFilter />
+  <UDPSendCount>2</UDPSendCount>
+  <UDPSendDelay>100</UDPSendDelay>
+  <IgnoreVirtualInterfaces>true</IgnoreVirtualInterfaces>
+  <VirtualInterfaceNames>vEthernet*</VirtualInterfaceNames>
+  <GatewayMonitorPeriod>60</GatewayMonitorPeriod>
+  <TrustAllIP6Interfaces>false</TrustAllIP6Interfaces>
+  <HDHomerunPortRange />
+  <PublishedServerUriBySubnet />
+  <AutoDiscoveryTracing>false</AutoDiscoveryTracing>
+  <AutoDiscovery>true</AutoDiscovery>
+  <PublicHttpsPort>8920</PublicHttpsPort>
+  <HttpServerPortNumber>__PORT__</HttpServerPortNumber>
+  <HttpsPortNumber>8920</HttpsPortNumber>
+  <EnableHttps>false</EnableHttps>
+  <EnableNormalizedItemByNameIds>true</EnableNormalizedItemByNameIds>
+  <CertificatePath />
+  <CertificatePassword />
+  <IsPortAuthorized>true</IsPortAuthorized>
+  <QuickConnectAvailable>false</QuickConnectAvailable>
+  <EnableRemoteAccess>true</EnableRemoteAccess>
+  <EnableCaseSensitiveItemIds>true</EnableCaseSensitiveItemIds>
+  <DisableLiveTvChannelUserDataName>true</DisableLiveTvChannelUserDataName>
+  <MetadataPath />
+  <MetadataNetworkPath />
+  <PreferredMetadataLanguage>en</PreferredMetadataLanguage>
+  <MetadataCountryCode>US</MetadataCountryCode>
+  <SortReplaceCharacters>
+    <string>.</string>
+    <string>+</string>
+    <string>%</string>
+  </SortReplaceCharacters>
+  <SortRemoveCharacters>
+    <string>,</string>
+    <string>&amp;</string>
+    <string>-</string>
+    <string>{</string>
+    <string>}</string>
+    <string>'</string>
+  </SortRemoveCharacters>
+  <SortRemoveWords>
+    <string>the</string>
+    <string>a</string>
+    <string>an</string>
+  </SortRemoveWords>
+  <MinResumePct>5</MinResumePct>
+  <MaxResumePct>90</MaxResumePct>
+  <MinResumeDurationSeconds>300</MinResumeDurationSeconds>
+  <MinAudiobookResume>5</MinAudiobookResume>
+  <MaxAudiobookResume>5</MaxAudiobookResume>
+  <LibraryMonitorDelay>60</LibraryMonitorDelay>
+  <EnableDashboardResponseCaching>true</EnableDashboardResponseCaching>
+  <ImageSavingConvention>Legacy</ImageSavingConvention>
+  <MetadataOptions>
+    <MetadataOptions>
+      <ItemType>Book</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers />
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>Movie</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers />
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>MusicVideo</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers>
+        <string>The Open Movie Database</string>
+      </DisabledMetadataFetchers>
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers>
+        <string>The Open Movie Database</string>
+      </DisabledImageFetchers>
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>Series</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers />
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>MusicAlbum</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers>
+        <string>TheAudioDB</string>
+      </DisabledMetadataFetchers>
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>MusicArtist</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers>
+        <string>TheAudioDB</string>
+      </DisabledMetadataFetchers>
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>BoxSet</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers />
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>Season</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers />
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+    <MetadataOptions>
+      <ItemType>Episode</ItemType>
+      <DisabledMetadataSavers />
+      <LocalMetadataReaderOrder />
+      <DisabledMetadataFetchers />
+      <MetadataFetcherOrder />
+      <DisabledImageFetchers />
+      <ImageFetcherOrder />
+    </MetadataOptions>
+  </MetadataOptions>
+  <SkipDeserializationForBasicTypes>true</SkipDeserializationForBasicTypes>
+  <ServerName />
+  <BaseUrl />
+  <UICulture>en-US</UICulture>
+  <SaveMetadataHidden>false</SaveMetadataHidden>
+  <ContentTypes />
+  <RemoteClientBitrateLimit>0</RemoteClientBitrateLimit>
+  <EnableFolderView>false</EnableFolderView>
+  <EnableGroupingIntoCollections>false</EnableGroupingIntoCollections>
+  <DisplaySpecialsWithinSeasons>true</DisplaySpecialsWithinSeasons>
+  <LocalNetworkSubnets />
+  <LocalNetworkAddresses />
+  <CodecsUsed />
+  <PluginRepositories>
+    <RepositoryInfo>
+      <Name>Jellyfin Stable</Name>
+      <Url>https://repo.jellyfin.org/releases/plugin/manifest-stable.json</Url>
+      <Enabled>true</Enabled>
+    </RepositoryInfo>
+  </PluginRepositories>
+  <EnableExternalContentInSuggestions>true</EnableExternalContentInSuggestions>
+  <RequireHttps>false</RequireHttps>
+  <EnableNewOmdbSupport>true</EnableNewOmdbSupport>
+  <RemoteIPFilter />
+  <IsRemoteIPFilterBlacklist>false</IsRemoteIPFilterBlacklist>
+  <ImageExtractionTimeoutMs>0</ImageExtractionTimeoutMs>
+  <PathSubstitutions />
+  <UninstalledPlugins />
+  <EnableSlowResponseWarning>true</EnableSlowResponseWarning>
+  <SlowResponseThresholdMs>500</SlowResponseThresholdMs>
+  <CorsHosts>
+    <string>*</string>
+  </CorsHosts>
+  <KnownProxies />
+  <ActivityLogRetentionDays>30</ActivityLogRetentionDays>
+  <LibraryScanFanoutConcurrency>0</LibraryScanFanoutConcurrency>
+  <LibraryMetadataRefreshConcurrency>0</LibraryMetadataRefreshConcurrency>
+  <RemoveOldPlugins>false</RemoveOldPlugins>
+</ServerConfiguration>

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -16,7 +16,12 @@ architecture=$(dpkg --print-architecture)
 discovery_service_port=1900
 discovery_client_port=7359
 
-ffmpeg_deps="libass9 libbluray2 libc6 libdrm-intel1 libdrm2 libfontconfig1 libfreetype6 libfribidi0 libgcc1 libgmp10 libgnutls30 libmp3lame0 libopus0 libstdc++6 libtheora0 libvdpau1 libvorbis0a libvorbisenc2 libvpx5 libwebp6 libwebpmux3 libx11-6 libx264-155 libx265-165 libzvbi0 libopencl1 zlib1g"
+if [ $architecture == "arm64" ]; then
+    ffmpeg_deps="libass9 libbluray2 libc6 libdrm2 libfontconfig1 libfreetype6 libfribidi0 libgcc1 libgmp10 libgnutls30 libmp3lame0 libopus0 libstdc++6 libtheora0 libvdpau1 libvorbis0a libvorbisenc2 libvpx5 libwebp6 libwebpmux3 libx11-6 libx264-155 libx265-165 libzvbi0 zlib1g"
+else
+    ffmpeg_deps="libass9 libbluray2 libc6 libdrm-intel1 libdrm2 libfontconfig1 libfreetype6 libfribidi0 libgcc1 libgmp10 libgnutls30 libmp3lame0 libopus0 libstdc++6 libtheora0 libvdpau1 libvorbis0a libvorbisenc2 libvpx5 libwebp6 libwebpmux3 libx11-6 libx264-155 libx265-165 libzvbi0 libopencl1 zlib1g"
+fi
+
 jellyfin_deps="at libsqlite3-0 libfontconfig1 libfreetype6 libssl1.1"
 pkg_dependencies="$ffmpeg_deps $jellyfin_deps"
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@ pkg_version="10.7.7-1"
 version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
 ffmpeg_pkg_version="4.3.2-1"
-ldap_pkg_version="14.0.0.0"
+ldap_pkg_version="12.0.0.0"
 
 architecture=$(dpkg --print-architecture)
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -16,6 +16,10 @@ architecture=$(dpkg --print-architecture)
 discovery_service_port=1900
 discovery_client_port=7359
 
+ffmpeg_deps="libass9 libbluray2 libc6 libdrm-intel1 libdrm2 libfontconfig1 libfreetype6 libfribidi0 libgcc1 libgmp10 libgnutls30 libmp3lame0 libopus0 libstdc++6 libtheora0 libvdpau1 libvorbis0a libvorbisenc2 libvpx5 libwebp6 libwebpmux3 libx11-6 libx264-155 libx265-165 libzvbi0 libopencl1 zlib1g"
+jellyfin_deps="at libsqlite3-0 libfontconfig1 libfreetype6 libssl1.1"
+pkg_dependencies="$ffmpeg_deps $jellyfin_deps"
+
 #=================================================
 # PERSONAL HELPERS
 #=================================================

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@ pkg_version="10.7.7-1"
 version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
 ffmpeg_pkg_version="4.3.2-1"
-ldap_pkg_version="12.0.0.0"
+ldap_pkg_version="14.0.0.0"
 
 architecture=$(dpkg --print-architecture)
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -61,7 +61,6 @@ ynh_backup --src_path="/etc/logrotate.d/$app"
 #=================================================
 
 ynh_backup --src_path="/etc/systemd/system/jellyfin.service.d" --not_mandatory
-ynh_backup --src_path="/lib/systemd/system/jellyfin.service"
 
 #=================================================
 # BACKUP VARIOUS FILES

--- a/scripts/install
+++ b/scripts/install
@@ -160,32 +160,11 @@ fi
 #=================================================
 ynh_script_progression --message="Configuring the settings..." --weight=1
 
-# Set permissions to app files
-chown -R $app: $final_path
-
-# Load services once to generate system.xml
-ynh_systemd_action --service_name=$app --action="restart" --log_path="systemd" --line_match="Started Jellyfin Media Server" --timeout=15
 ynh_systemd_action --service_name=$app --action="stop" --log_path="systemd" --line_match="Stopped Jellyfin Media Server" --timeout=15
 
-# Port config
-ynh_replace_string --match_string="<PublicPort>8096</PublicPort>" --replace_string="<PublicPort>$port</PublicPort>" --target_file="$config_path/network.xml"
-ynh_replace_string --match_string="<HttpServerPortNumber>8096</HttpServerPortNumber>" --replace_string="<HttpServerPortNumber>$port</HttpServerPortNumber>" --target_file="$config_path/network.xml"
-
-# Enable IPv6
-ynh_replace_string --match_string="<EnableIPV6>false</EnableIPV6>" --replace_string="<EnableIPV6>true</EnableIPV6>" --target_file="$config_path/network.xml"
-
-# BaseUrl config
-ynh_replace_string --match_string="<BaseUrl />" --replace_string="<BaseUrl>$path_url</BaseUrl>" --target_file="$config_path/network.xml"
-
-# Disable Setup Wizard
-ynh_replace_string --match_string="<IsStartupWizardCompleted>false</IsStartupWizardCompleted>" --replace_string="<IsStartupWizardCompleted>true</IsStartupWizardCompleted>" --target_file="$config_path/system.xml"
-
-# Lower logging verbosity
-cp "$config_path/logging.default.json" "$config_path/logging.json"
-ynh_replace_string --match_string="\"Default\": \"Information\"" --replace_string="\"Default\": \"Error\"" --target_file="$config_path/logging.json"
-
-ynh_store_file_checksum --file="$config_path/network.xml"
-ynh_store_file_checksum --file="$config_path/system.xml"
+ynh_add_config --template="system.xml" --destination="$config_path/system.xml"
+ynh_add_config --template="network.xml" --destination="$config_path/network.xml"
+ynh_add_config --template="logging.json" --destination="$config_path/logging.json"
 
 #=================================================
 # INSTALL LDAP PLUGIN
@@ -194,7 +173,7 @@ ynh_script_progression --message="Installing LDAP plugin..." --weight=2
 
 ynh_setup_source --dest_dir="/var/lib/jellyfin/plugins/LDAP Authentication" --source_id=ldap
 mkdir -p /var/lib/jellyfin/plugins/configurations/
-ynh_add_config --template="../conf/LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
+ynh_add_config --template="LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/install
+++ b/scripts/install
@@ -108,7 +108,18 @@ tempdir="$(mktemp -d)"
 
 # Download the deb files
 ynh_setup_source --dest_dir=$tempdir --source_id="ffmpeg.$architecture"
+# In case of a new version, the url change from https://repo.jellyfin.org/releases/server/debian/versions/stable/server/X.X.X/jellyfin-server_X.X.X-1_$architecture.deb to https://repo.jellyfin.org/archive/debian/stable/X.X.X/server/jellyfin-server_X.X.X-1_$architecture.deb
+src_url=$(grep 'SOURCE_URL=' "../conf/server.$architecture.src" | cut -d= -f2-)
+if ! curl --output /dev/null --silent --head --fail "$src_url"; then
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/server/$version/jellyfin-server_$version-1_$architecture.deb" --replace_string="archive/debian/stable/$version/server/jellyfin-server_$version-1_$architecture.deb" --target_file="../conf/server.$architecture.src"
+fi
 ynh_setup_source --dest_dir=$tempdir --source_id="server.$architecture"
+
+# Same for web
+src_url=$(grep 'SOURCE_URL=' "../conf/web.$architecture.src" | cut -d= -f2-)
+if ! curl --output /dev/null --silent --head --fail "$src_url"; then
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/web/$version/jellyfin-web_$version-1_all.deb" --replace_string="archive/debian/stable/$version/web/jellyfin-web_$version-1_all.deb" --target_file="../conf/web.$architecture.src"
+fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages

--- a/scripts/install
+++ b/scripts/install
@@ -101,7 +101,14 @@ ynh_app_setting_set --app=$app --key=discovery_client --value=$discovery_client
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Installing dependencies..." --weight=1
+ynh_script_progression --message="Installing dependencies..." --weight=5
+
+ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
+# INSTALL PACKAGES
+#=================================================
+ynh_script_progression --message="Installing packages..." --weight=1
 
 # Create the temporary directory
 tempdir="$(mktemp -d)"
@@ -123,9 +130,9 @@ fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-ffmpeg.deb -y
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-server.deb -y
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-web.deb -y
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-ffmpeg.deb
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-server.deb
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-web.deb
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -38,7 +38,7 @@ fi
 #=================================================
 # REMOVE DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Removing dependencies" --weight=3
+ynh_script_progression --message="Removing dependencies..." --weight=3
 
 ynh_remove_app_dependencies
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -38,11 +38,18 @@ fi
 #=================================================
 # REMOVE DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Removing dependencies..." --weight=1
+ynh_script_progression --message="Removing dependencies" --weight=3
 
-apt-get remove jellyfin-web -y
-apt-get remove jellyfin-server -y
-apt-get remove jellyfin-ffmpeg -y
+ynh_remove_app_dependencies
+
+#=================================================
+# REMOVE PACKAGES
+#=================================================
+ynh_script_progression --message="Removing packages..." --weight=1
+
+dpkg --remove jellyfin-web
+dpkg --remove jellyfin-server
+dpkg --remove jellyfin-ffmpeg
 
 #=================================================
 # REMOVE APP DIRECTORIES

--- a/scripts/restore
+++ b/scripts/restore
@@ -139,9 +139,9 @@ fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages
-ynh_exec_warn_less dpkg -i $tempdir/jellyfin-ffmpeg.deb --force-confdef --force-confold
-ynh_exec_warn_less dpkg -i $tempdir/jellyfin-server.deb --force-confdef --force-confold
-ynh_exec_warn_less dpkg -i $tempdir/jellyfin-web.deb --force-confdef --force-confold
+ynh_exec_warn_less dpkg --force-confdef --force-confold -i $tempdir/jellyfin-ffmpeg.deb
+ynh_exec_warn_less dpkg --force-confdef --force-confold -i $tempdir/jellyfin-server.deb
+ynh_exec_warn_less dpkg --force-confdef --force-confold -i $tempdir/jellyfin-web.deb
 
 #=================================================
 # RESTORE SYSTEMD

--- a/scripts/restore
+++ b/scripts/restore
@@ -149,7 +149,6 @@ ynh_exec_warn_less dpkg --force-confdef --force-confold -i $tempdir/jellyfin-web
 ynh_script_progression --message="Restoring the systemd configuration..." --weight=1
 
 ynh_restore_file --origin_path="/etc/systemd/system/jellyfin.service.d" --not_mandatory
-ynh_restore_file --origin_path="/lib/systemd/system/jellyfin.service"
 systemctl enable jellyfin.service --quiet
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -125,16 +125,16 @@ tempdir="$(mktemp -d)"
 # Download the deb files
 ynh_setup_source --dest_dir=$tempdir --source_id="ffmpeg.$architecture"
 # In case of a new version, the url change from https://repo.jellyfin.org/releases/server/debian/versions/stable/server/X.X.X/jellyfin-server_X.X.X-1_$architecture.deb to https://repo.jellyfin.org/archive/debian/stable/X.X.X/server/jellyfin-server_X.X.X-1_$architecture.deb
-src_url=$(grep 'SOURCE_URL=' "../conf/server.$architecture.src" | cut -d= -f2-)
+src_url=$(grep 'SOURCE_URL=' "../settings/conf/server.$architecture.src" | cut -d= -f2-)
 if ! curl --output /dev/null --silent --head --fail "$src_url"; then
-	ynh_replace_string --match_string="releases/server/debian/versions/stable/server/$version/jellyfin-server_$version-1_$architecture.deb" --replace_string="archive/debian/stable/$version/server/jellyfin-server_$version-1_$architecture.deb" --target_file="../conf/server.$architecture.src"
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/server/$version/jellyfin-server_$version-1_$architecture.deb" --replace_string="archive/debian/stable/$version/server/jellyfin-server_$version-1_$architecture.deb" --target_file="../settings/conf/server.$architecture.src"
 fi
 ynh_setup_source --dest_dir=$tempdir --source_id="server.$architecture"
 
 # Same for web
-src_url=$(grep 'SOURCE_URL=' "../conf/web.$architecture.src" | cut -d= -f2-)
+src_url=$(grep 'SOURCE_URL=' "../settings/conf/web.$architecture.src" | cut -d= -f2-)
 if ! curl --output /dev/null --silent --head --fail "$src_url"; then
-	ynh_replace_string --match_string="releases/server/debian/versions/stable/web/$version/jellyfin-web_$version-1_all.deb" --replace_string="archive/debian/stable/$version/web/jellyfin-web_$version-1_all.deb" --target_file="../conf/web.$architecture.src"
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/web/$version/jellyfin-web_$version-1_all.deb" --replace_string="archive/debian/stable/$version/web/jellyfin-web_$version-1_all.deb" --target_file="../settings/conf/web.$architecture.src"
 fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -116,7 +116,18 @@ tempdir="$(mktemp -d)"
 
 # Download the deb files
 ynh_setup_source --dest_dir=$tempdir --source_id="ffmpeg.$architecture"
+# In case of a new version, the url change from https://repo.jellyfin.org/releases/server/debian/versions/stable/server/X.X.X/jellyfin-server_X.X.X-1_$architecture.deb to https://repo.jellyfin.org/archive/debian/stable/X.X.X/server/jellyfin-server_X.X.X-1_$architecture.deb
+src_url=$(grep 'SOURCE_URL=' "../conf/server.$architecture.src" | cut -d= -f2-)
+if ! curl --output /dev/null --silent --head --fail "$src_url"; then
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/server/$version/jellyfin-server_$version-1_$architecture.deb" --replace_string="archive/debian/stable/$version/server/jellyfin-server_$version-1_$architecture.deb" --target_file="../conf/server.$architecture.src"
+fi
 ynh_setup_source --dest_dir=$tempdir --source_id="server.$architecture"
+
+# Same for web
+src_url=$(grep 'SOURCE_URL=' "../conf/web.$architecture.src" | cut -d= -f2-)
+if ! curl --output /dev/null --silent --head --fail "$src_url"; then
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/web/$version/jellyfin-web_$version-1_all.deb" --replace_string="archive/debian/stable/$version/web/jellyfin-web_$version-1_all.deb" --target_file="../conf/web.$architecture.src"
+fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages

--- a/scripts/restore
+++ b/scripts/restore
@@ -109,7 +109,15 @@ ynh_system_user_create --username=$app
 #=================================================
 # REINSTALL DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Reinstalling dependencies..." --weight=7
+ynh_script_progression --message="Reinstalling dependencies..." --weight=5
+
+# Define and install dependencies
+ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
+# REINSTALL PACKAGES
+#=================================================
+ynh_script_progression --message="Reinstalling packages..." --weight=7
 
 # Create the temporary directory
 tempdir="$(mktemp -d)"
@@ -131,9 +139,9 @@ fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-ffmpeg.deb -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-server.deb -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-web.deb -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-ffmpeg.deb --force-confdef --force-confold
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-server.deb --force-confdef --force-confold
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-web.deb --force-confdef --force-confold
 
 #=================================================
 # RESTORE SYSTEMD

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -181,41 +181,11 @@ ynh_system_user_create --username=$app
 #=================================================
 # MODIFY A CONFIG FILE
 #=================================================
+ynh_script_progression --message="Setting up configuration files..." --weight=2
 
-# Check if network.xml exists (introduced in v10.7)
-if [ -f "/etc/jellyfin/network.xml" ]; then
-	ynh_script_progression --message="Configuring the settings..." --weight=1
-
-	ynh_backup_if_checksum_is_different --file="$config_path/network.xml"
-	ynh_backup_if_checksum_is_different --file="$config_path/system.xml"
-
-	# Set permissions to app files
-	chown -R $app: $final_path
-
-	# Load services once to generate network.xml
-	ynh_systemd_action --service_name=$app --action="restart" --log_path="systemd" --line_match="Started Jellyfin Media Server" --timeout=15
-	ynh_systemd_action --service_name=$app --action="stop" --log_path="systemd" --line_match="Stopped Jellyfin Media Server" --timeout=15
-
-	# Port config
-	ynh_replace_string --match_string="<PublicPort>8096</PublicPort>" --replace_string="<PublicPort>$port</PublicPort>" --target_file="$config_path/network.xml"
-	ynh_replace_string --match_string="<HttpServerPortNumber>8096</HttpServerPortNumber>" --replace_string="<HttpServerPortNumber>$port</HttpServerPortNumber>" --target_file="$config_path/network.xml"
-
-	# Enable IPv6
-	ynh_replace_string --match_string="<EnableIPV6>false</EnableIPV6>" --replace_string="<EnableIPV6>true</EnableIPV6>" --target_file="$config_path/network.xml"
-
-	# BaseUrl config
-	ynh_replace_string --match_string="<BaseUrl />" --replace_string="<BaseUrl>$path_url</BaseUrl>" --target_file="$config_path/network.xml"
-
-	ynh_store_file_checksum --file="$config_path/network.xml"
-	ynh_store_file_checksum --file="$config_path/system.xml"
-fi
-
-# Lower logging verbosity
-# But first, if missing, copy it from its template
-if [ ! -f "$config_path/logging.json" ]; then
-	cp "$config_path/logging.default.json" "$config_path/logging.json"
-fi
-ynh_exec_fully_quiet ynh_replace_string --match_string="\"Default\": \"Information\"" --replace_string="\"Default\": \"Error\"" --target_file="$config_path/logging.json"
+ynh_add_config --template="system.xml" --destination="$config_path/system.xml"
+ynh_add_config --template="network.xml" --destination="$config_path/network.xml"
+ynh_add_config --template="logging.json" --destination="$config_path/logging.json"
 
 #=================================================
 # INSTALL LDAP PLUGIN
@@ -224,7 +194,7 @@ ynh_script_progression --message="Installing LDAP plugin..." --weight=2
 
 ynh_setup_source --dest_dir="/var/lib/jellyfin/plugins/LDAP Authentication" --source_id=ldap
 mkdir -p /var/lib/jellyfin/plugins/configurations/
-ynh_add_config --template="../conf/LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
+ynh_add_config --template="LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -166,9 +166,9 @@ fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages
-ynh_exec_warn_less dpkg -i $tempdir/jellyfin-ffmpeg.deb --force-confdef --force-confnew
-ynh_exec_warn_less dpkg -i $tempdir/jellyfin-server.deb --force-confdef --force-confnew
-ynh_exec_warn_less dpkg -i $tempdir/jellyfin-web.deb --force-confdef --force-confnew
+ynh_exec_warn_less dpkg --force-confdef --force-confnew -i $tempdir/jellyfin-ffmpeg.deb
+ynh_exec_warn_less dpkg --force-confdef --force-confnew -i $tempdir/jellyfin-server.deb
+ynh_exec_warn_less dpkg --force-confdef --force-confnew -i $tempdir/jellyfin-web.deb
 
 #=================================================
 # CREATE DEDICATED USER

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -144,7 +144,18 @@ tempdir="$(mktemp -d)"
 
 # Download the deb files
 ynh_setup_source --dest_dir=$tempdir --source_id="ffmpeg.$architecture"
+# In case of a new version, the url change from https://repo.jellyfin.org/releases/server/debian/versions/stable/server/X.X.X/jellyfin-server_X.X.X-1_$architecture.deb to https://repo.jellyfin.org/archive/debian/stable/X.X.X/server/jellyfin-server_X.X.X-1_$architecture.deb
+src_url=$(grep 'SOURCE_URL=' "../conf/server.$architecture.src" | cut -d= -f2-)
+if ! curl --output /dev/null --silent --head --fail "$src_url"; then
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/server/$version/jellyfin-server_$version-1_$architecture.deb" --replace_string="archive/debian/stable/$version/server/jellyfin-server_$version-1_$architecture.deb" --target_file="../conf/server.$architecture.src"
+fi
 ynh_setup_source --dest_dir=$tempdir --source_id="server.$architecture"
+
+# Same for web
+src_url=$(grep 'SOURCE_URL=' "../conf/web.$architecture.src" | cut -d= -f2-)
+if ! curl --output /dev/null --silent --head --fail "$src_url"; then
+	ynh_replace_string --match_string="releases/server/debian/versions/stable/web/$version/jellyfin-web_$version-1_all.deb" --replace_string="archive/debian/stable/$version/web/jellyfin-web_$version-1_all.deb" --target_file="../conf/web.$architecture.src"
+fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -137,7 +137,14 @@ ynh_add_nginx_config
 #=================================================
 # UPGRADE DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Upgrading dependencies..." --weight=3
+ynh_script_progression --message="Upgrading dependencies..." --weight=5
+
+ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
+# UPGRADE packages
+#=================================================
+ynh_script_progression --message="Upgrading packages..." --weight=3
 
 # Create the temporary directory
 tempdir="$(mktemp -d)"
@@ -159,9 +166,9 @@ fi
 ynh_setup_source --dest_dir=$tempdir --source_id="web.$architecture"
 
 # Install the packages
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-ffmpeg.deb -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-server.deb -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew
-ynh_exec_warn_less apt-get -f install $tempdir/jellyfin-web.deb -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-ffmpeg.deb --force-confdef --force-confnew
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-server.deb --force-confdef --force-confnew
+ynh_exec_warn_less dpkg -i $tempdir/jellyfin-web.deb --force-confdef --force-confnew
 
 #=================================================
 # CREATE DEDICATED USER


### PR DESCRIPTION
## Problem

- *When a new version of Jellyfin is available, the url of the previous version is no longer valid.*

## Solution

- *Change the url if needed*
- *Use dpkg to remove a linter's warning*
- *Bump ldap version*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
