### PR TITLE
Upgrade to 10.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Media System that manage and stream your media.
 
-**Shipped version:** 10.7.7~ynh3
+**Shipped version:** 10.8.0~ynh1
 
 **Demo:** https://demo.jellyfin.org/stable/web/index.html
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Système multimédia qui gère et diffuse vos médias.
 
-**Version incluse :** 10.7.7~ynh3
+**Version incluse :** 10.8.0~ynh1
 
 **Démo :** https://demo.jellyfin.org/stable/web/index.html
 

--- a/conf/ffmpeg.bullseye.amd64.src
+++ b/conf/ffmpeg.bullseye.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-bullseye_amd64.deb
-SOURCE_SUM=78e0c7594171bf0f10cc2a3c779434c6850c99e6a74a94bd1be0cf320e580b32
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-5/jellyfin-ffmpeg5_5.0.1-5-bullseye_amd64.deb
+SOURCE_SUM=8070eb09a73912da19c4659b8f8e8f3aac70bac62601195d15b03c7c419adc55
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/ffmpeg.bullseye.amd64.src
+++ b/conf/ffmpeg.bullseye.amd64.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/4.3.2-1/jellyfin-ffmpeg_4.3.2-1-bullseye_amd64.deb
-SOURCE_SUM=00bfda23ba65427566a50ce17876973c20350b69cd9ebd069cd7c6f7706414e8
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-bullseye_amd64.deb
+SOURCE_SUM=78e0c7594171bf0f10cc2a3c779434c6850c99e6a74a94bd1be0cf320e580b32
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false
 SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin-ffmpeg.deb
+SOURCE_FILENAME=jellyfin-ffmpeg5.deb

--- a/conf/ffmpeg.bullseye.arm64.src
+++ b/conf/ffmpeg.bullseye.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-bullseye_arm64.deb
-SOURCE_SUM=5a85f9a2a720f03dea645eaa3ecfadc46d743f9ae82e8bbad9d1aaa7d5f9cc6b
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-5/jellyfin-ffmpeg5_5.0.1-5-bullseye_arm64.deb
+SOURCE_SUM=7aeff16cee434c1732ab3a7b6bfc949b2714b6bd432fff147fe8bb9424de85c8
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/ffmpeg.bullseye.arm64.src
+++ b/conf/ffmpeg.bullseye.arm64.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/4.3.2-1/jellyfin-ffmpeg_4.3.2-1-bullseye_arm64.deb
-SOURCE_SUM=e8dce4cc4904cae5efaa2ab1f0dd6345ab840548f944352628827696a2d9625f
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-bullseye_arm64.deb
+SOURCE_SUM=5a85f9a2a720f03dea645eaa3ecfadc46d743f9ae82e8bbad9d1aaa7d5f9cc6b
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false
 SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin-ffmpeg.deb
+SOURCE_FILENAME=jellyfin-ffmpeg5.deb

--- a/conf/ffmpeg.bullseye.armhf.src
+++ b/conf/ffmpeg.bullseye.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-bullseye_armhf.deb
-SOURCE_SUM=52fe443d8cf69714133535da88c5e40e0f30fda2d73d1dee4a9c57d56e51a0e2
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-5/jellyfin-ffmpeg5_5.0.1-5-bullseye_armhf.deb
+SOURCE_SUM=ae59fc84b52176618debebf211dcba083663a4bb82747a320bee64558cfb6ccc
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/ffmpeg.bullseye.armhf.src
+++ b/conf/ffmpeg.bullseye.armhf.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/4.3.2-1/jellyfin-ffmpeg_4.3.2-1-bullseye_armhf.deb
-SOURCE_SUM=1d02c43218d785e4e2218a413950a6c16ab852e3e409ddad494a1ae5cf5a7e02
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-bullseye_armhf.deb
+SOURCE_SUM=52fe443d8cf69714133535da88c5e40e0f30fda2d73d1dee4a9c57d56e51a0e2
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false
 SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin-ffmpeg.deb
+SOURCE_FILENAME=jellyfin-ffmpeg5.deb

--- a/conf/ffmpeg.buster.amd64.src
+++ b/conf/ffmpeg.buster.amd64.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/4.3.2-1/jellyfin-ffmpeg_4.3.2-1-buster_amd64.deb
-SOURCE_SUM=54987f4ede995e50e6662e7741df5205005b7e8d881af8145b71d319df6f0cb2
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-buster_amd64.deb
+SOURCE_SUM=168c9fac392d2ac8a1faba94ac8cf059efec6762aa8ad2d3b66396fddbbc675b
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false
 SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin-ffmpeg.deb
+SOURCE_FILENAME=jellyfin-ffmpeg5.deb

--- a/conf/ffmpeg.buster.amd64.src
+++ b/conf/ffmpeg.buster.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-buster_amd64.deb
-SOURCE_SUM=168c9fac392d2ac8a1faba94ac8cf059efec6762aa8ad2d3b66396fddbbc675b
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-5/jellyfin-ffmpeg5_5.0.1-5-buster_amd64.deb
+SOURCE_SUM=d1079c74f6d644fb7accf02232583e3c78100c57c5af8c24914d67250cdb3d0d
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/ffmpeg.buster.arm64.src
+++ b/conf/ffmpeg.buster.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-buster_arm64.deb
-SOURCE_SUM=5aa1feb2926bb678bb99e9f7192a20d27cbec94d86c370ca736a5b9ba648e0af
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-5/jellyfin-ffmpeg5_5.0.1-5-buster_arm64.deb
+SOURCE_SUM=3c732da2f365faf7c7c859602e07da114ba63dcac69c54daa8403171c6a955ec
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/ffmpeg.buster.arm64.src
+++ b/conf/ffmpeg.buster.arm64.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/4.3.2-1/jellyfin-ffmpeg_4.3.2-1-buster_arm64.deb
-SOURCE_SUM=02b8ee277f428b0519036b1657873ec65c124090f605daa235de10eb7c5a381d
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-buster_arm64.deb
+SOURCE_SUM=5aa1feb2926bb678bb99e9f7192a20d27cbec94d86c370ca736a5b9ba648e0af
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false
 SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin-ffmpeg.deb
+SOURCE_FILENAME=jellyfin-ffmpeg5.deb

--- a/conf/ffmpeg.buster.armhf.src
+++ b/conf/ffmpeg.buster.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-buster_armhf.deb
-SOURCE_SUM=3a3655b11ba9b9acfb79568ecd6a04074ccf8d843893bb5dd1f1d50565d6e455
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-5/jellyfin-ffmpeg5_5.0.1-5-buster_armhf.deb
+SOURCE_SUM=8c3d65b68e56b1ee26dec1727f514946e04bd4fefab9b40c2df12f3d80f54ba6
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/ffmpeg.buster.armhf.src
+++ b/conf/ffmpeg.buster.armhf.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/4.3.2-1/jellyfin-ffmpeg_4.3.2-1-buster_armhf.deb
-SOURCE_SUM=04e99a82aae906af6fd526bfbde22b6a8ea2b3b2bb1460561ff2c543b0963d4f
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/5.0.1-3/jellyfin-ffmpeg5_5.0.1-3-buster_armhf.deb
+SOURCE_SUM=3a3655b11ba9b9acfb79568ecd6a04074ccf8d843893bb5dd1f1d50565d6e455
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false
 SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin-ffmpeg.deb
+SOURCE_FILENAME=jellyfin-ffmpeg5.deb

--- a/conf/ffmpeg.src.default
+++ b/conf/ffmpeg.src.default
@@ -1,7 +1,7 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/__FFMPEG_PKG_VERSION__/jellyfin-ffmpeg___FFMPEG_PKG_VERSION__-__DEBIAN_____ARCHITECTURE__.deb
-SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/__FFMPEG_PKG_VERSION__/jellyfin-ffmpeg___FFMPEG_PKG_VERSION__-__DEBIAN_____ARCHITECTURE__.deb.sha256sum
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/__FFMPEG_PKG_VERSION__/jellyfin-ffmpeg5___FFMPEG_PKG_VERSION__-__DEBIAN_____ARCHITECTURE__.deb
+SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/__FFMPEG_PKG_VERSION__/jellyfin-ffmpeg5___FFMPEG_PKG_VERSION__-__DEBIAN_____ARCHITECTURE__.deb.sha256sum
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false
 SOURCE_EXTRACT=false
-SOURCE_FILENAME=jellyfin-ffmpeg.deb
+SOURCE_FILENAME=jellyfin-ffmpeg5.deb

--- a/conf/ldap.src
+++ b/conf/ldap.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_12.0.0.0.zip
-SOURCE_SUM=e3ef05fdb0cce145504a34595aefe568e47964e981017d9ccb87f39e58fff861
+SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_14.0.0.0.zip
+SOURCE_SUM=2306435e74d0a48bb41d83e000461136ab5a77fff5636fc246a90859701a29c1
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/ldap.src
+++ b/conf/ldap.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_14.0.0.0.zip
-SOURCE_SUM=2306435e74d0a48bb41d83e000461136ab5a77fff5636fc246a90859701a29c1
+SOURCE_URL=https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_15.0.0.0.zip
+SOURCE_SUM=e0fa2ee4ec0bbe3a6f56fd5775abe1dd41cde88f05d9c085e9135cda4680c00c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.amd64.src
+++ b/conf/server.bullseye.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.7.7/jellyfin-server_10.7.7-1_amd64.deb
-SOURCE_SUM=938c8be07e2d183b4ee23a0f01f78d140ecb7f58aadc7c0a6105b2e4382c7a4e
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_amd64.deb
+SOURCE_SUM=4f902f461e491090fd20c5285fdf1c465011c9107f08e98eaba938611e975228
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.amd64.src
+++ b/conf/server.bullseye.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_amd64.deb
-SOURCE_SUM=4f902f461e491090fd20c5285fdf1c465011c9107f08e98eaba938611e975228
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.0/jellyfin-server_10.8.0-1_amd64.deb
+SOURCE_SUM=af0b6133fe9df3b9096c3cd329a4a7df1664279a3903f47e8b003670305ac761
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.arm64.src
+++ b/conf/server.bullseye.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_arm64.deb
-SOURCE_SUM=14d502242665a5c01d2abe4facda2c8c18ff2e43631963e5b6ca037811d5915b
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.0/jellyfin-server_10.8.0-1_arm64.deb
+SOURCE_SUM=1e594290beb3128f03221c4e5bcaa5b2f8fada1ade519fcc60d12f466fd090ec
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.arm64.src
+++ b/conf/server.bullseye.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.7.7/jellyfin-server_10.7.7-1_arm64.deb
-SOURCE_SUM=0c42e615382fa567d8e274e77a65632f878680536eaf2bd77fb13a09dc59ada9
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_arm64.deb
+SOURCE_SUM=14d502242665a5c01d2abe4facda2c8c18ff2e43631963e5b6ca037811d5915b
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.armhf.src
+++ b/conf/server.bullseye.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_armhf.deb
-SOURCE_SUM=0a5cb9388f4b75835f5b11adcabbd0691280431b2e62cbc75c5ab1a604b118cb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.0/jellyfin-server_10.8.0-1_armhf.deb
+SOURCE_SUM=4acfcdb8f70fb57615ea66fdbf400b9e1a990bd95439b94479fd101cf657c340
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.armhf.src
+++ b/conf/server.bullseye.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.7.7/jellyfin-server_10.7.7-1_armhf.deb
-SOURCE_SUM=685931c972ad044fbdc2ccbea07a5aaf75f93e99562ea799cd6e5a7ac4bdb0cf
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_armhf.deb
+SOURCE_SUM=0a5cb9388f4b75835f5b11adcabbd0691280431b2e62cbc75c5ab1a604b118cb
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.amd64.src
+++ b/conf/server.buster.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.7.7/jellyfin-server_10.7.7-1_amd64.deb
-SOURCE_SUM=938c8be07e2d183b4ee23a0f01f78d140ecb7f58aadc7c0a6105b2e4382c7a4e
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_amd64.deb
+SOURCE_SUM=4f902f461e491090fd20c5285fdf1c465011c9107f08e98eaba938611e975228
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.amd64.src
+++ b/conf/server.buster.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_amd64.deb
-SOURCE_SUM=4f902f461e491090fd20c5285fdf1c465011c9107f08e98eaba938611e975228
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.0/jellyfin-server_10.8.0-1_amd64.deb
+SOURCE_SUM=af0b6133fe9df3b9096c3cd329a4a7df1664279a3903f47e8b003670305ac761
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.arm64.src
+++ b/conf/server.buster.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_arm64.deb
-SOURCE_SUM=14d502242665a5c01d2abe4facda2c8c18ff2e43631963e5b6ca037811d5915b
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.0/jellyfin-server_10.8.0-1_arm64.deb
+SOURCE_SUM=1e594290beb3128f03221c4e5bcaa5b2f8fada1ade519fcc60d12f466fd090ec
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.arm64.src
+++ b/conf/server.buster.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.7.7/jellyfin-server_10.7.7-1_arm64.deb
-SOURCE_SUM=0c42e615382fa567d8e274e77a65632f878680536eaf2bd77fb13a09dc59ada9
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_arm64.deb
+SOURCE_SUM=14d502242665a5c01d2abe4facda2c8c18ff2e43631963e5b6ca037811d5915b
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.armhf.src
+++ b/conf/server.buster.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_armhf.deb
-SOURCE_SUM=0a5cb9388f4b75835f5b11adcabbd0691280431b2e62cbc75c5ab1a604b118cb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.0/jellyfin-server_10.8.0-1_armhf.deb
+SOURCE_SUM=4acfcdb8f70fb57615ea66fdbf400b9e1a990bd95439b94479fd101cf657c340
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.armhf.src
+++ b/conf/server.buster.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.7.7/jellyfin-server_10.7.7-1_armhf.deb
-SOURCE_SUM=685931c972ad044fbdc2ccbea07a5aaf75f93e99562ea799cd6e5a7ac4bdb0cf
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/10.8.0-beta2/jellyfin-server_10.8.0~beta2_armhf.deb
+SOURCE_SUM=0a5cb9388f4b75835f5b11adcabbd0691280431b2e62cbc75c5ab1a604b118cb
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.src.default
+++ b/conf/server.src.default
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb
-SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb.sha256sum
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb
+SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb.sha256sum
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.src.default
+++ b/conf/server.src.default
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb
-SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb.sha256sum
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb
+SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/__VERSION__/jellyfin-server___PKG_VERSION_____ARCHITECTURE__.deb.sha256sum
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.amd64.src
+++ b/conf/web.bullseye.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.7.7/jellyfin-web_10.7.7-1_all.deb
-SOURCE_SUM=ca06cc1be55cb0393de9cd002e5cd422b7746c68341125b8f4c18907c59647c8
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
+SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.amd64.src
+++ b/conf/web.bullseye.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
-SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.0/jellyfin-web_10.8.0-1_all.deb
+SOURCE_SUM=f5e5861f3e9941cef17fbd04d294a6f538f258f6167ef5201b97632167cd3af4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.arm64.src
+++ b/conf/web.bullseye.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.7.7/jellyfin-web_10.7.7-1_all.deb
-SOURCE_SUM=ca06cc1be55cb0393de9cd002e5cd422b7746c68341125b8f4c18907c59647c8
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
+SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.arm64.src
+++ b/conf/web.bullseye.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
-SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.0/jellyfin-web_10.8.0-1_all.deb
+SOURCE_SUM=f5e5861f3e9941cef17fbd04d294a6f538f258f6167ef5201b97632167cd3af4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.armhf.src
+++ b/conf/web.bullseye.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.7.7/jellyfin-web_10.7.7-1_all.deb
-SOURCE_SUM=ca06cc1be55cb0393de9cd002e5cd422b7746c68341125b8f4c18907c59647c8
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
+SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.armhf.src
+++ b/conf/web.bullseye.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
-SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.0/jellyfin-web_10.8.0-1_all.deb
+SOURCE_SUM=f5e5861f3e9941cef17fbd04d294a6f538f258f6167ef5201b97632167cd3af4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.amd64.src
+++ b/conf/web.buster.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.7.7/jellyfin-web_10.7.7-1_all.deb
-SOURCE_SUM=ca06cc1be55cb0393de9cd002e5cd422b7746c68341125b8f4c18907c59647c8
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
+SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.amd64.src
+++ b/conf/web.buster.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
-SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.0/jellyfin-web_10.8.0-1_all.deb
+SOURCE_SUM=f5e5861f3e9941cef17fbd04d294a6f538f258f6167ef5201b97632167cd3af4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.arm64.src
+++ b/conf/web.buster.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.7.7/jellyfin-web_10.7.7-1_all.deb
-SOURCE_SUM=ca06cc1be55cb0393de9cd002e5cd422b7746c68341125b8f4c18907c59647c8
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
+SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.arm64.src
+++ b/conf/web.buster.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
-SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.0/jellyfin-web_10.8.0-1_all.deb
+SOURCE_SUM=f5e5861f3e9941cef17fbd04d294a6f538f258f6167ef5201b97632167cd3af4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.armhf.src
+++ b/conf/web.buster.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.7.7/jellyfin-web_10.7.7-1_all.deb
-SOURCE_SUM=ca06cc1be55cb0393de9cd002e5cd422b7746c68341125b8f4c18907c59647c8
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
+SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.armhf.src
+++ b/conf/web.buster.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/10.8.0-beta2/jellyfin-web_10.8.0~beta2_all.deb
-SOURCE_SUM=ac80cf86e4abb15736ce455a418db7239d3da09bbca5ccf8dc8d6c3c30e1aff0
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.0/jellyfin-web_10.8.0-1_all.deb
+SOURCE_SUM=f5e5861f3e9941cef17fbd04d294a6f538f258f6167ef5201b97632167cd3af4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.src.default
+++ b/conf/web.src.default
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb
-SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb.sha256sum
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb
+SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb.sha256sum
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.src.default
+++ b/conf/web.src.default
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb
-SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb.sha256sum
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb
+SOURCE_SUM=https://repo.jellyfin.org/releases/server/debian/versions/stable-pre/web/__VERSION__/jellyfin-web___PKG_VERSION___all.deb.sha256sum
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Media System that manage and stream your media.",
         "fr": "Système multimédia qui gère et diffuse vos médias."
     },
-    "version": "10.7.7~ynh3",
+    "version": "10.8.0-beta2~ynh1",
     "url": "https://jellyfin.org",
     "upstream": {
         "license": "GPL-2.0-only",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Media System that manage and stream your media.",
         "fr": "Système multimédia qui gère et diffuse vos médias."
     },
-    "version": "10.8.0-beta2~ynh1",
+    "version": "10.8.0~ynh1",
     "url": "https://jellyfin.org",
     "upstream": {
         "license": "GPL-2.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,11 +5,12 @@
 #=================================================
 
 debian=$(lsb_release --codename --short)
-pkg_version="10.7.7-1"
-version=$(echo "$pkg_version" | cut -d '-' -f 1)
+pkg_version="10.8.0~beta2"
+version=10.8.0-beta2
+# version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
-ffmpeg_pkg_version="4.3.2-1"
-ldap_pkg_version="12.0.0.0"
+ffmpeg_pkg_version="5.0.1-3"
+ldap_pkg_version="14.0.0.0"
 
 architecture=$(dpkg --print-architecture)
 
@@ -90,7 +91,7 @@ install_jellyfin_packages() {
     ynh_setup_source --dest_dir=$tempdir --source_id="web.$debian.$architecture"
 
     # Install the packages
-    ynh_exec_warn_less dpkg --force-confdef --force-confnew -i $tempdir/jellyfin-ffmpeg.deb
+    ynh_exec_warn_less dpkg --force-confdef --force-confnew -i $tempdir/jellyfin-ffmpeg5.deb
     ynh_exec_warn_less dpkg --force-confdef --force-confnew -i $tempdir/jellyfin-server.deb
     ynh_exec_warn_less dpkg --force-confdef --force-confnew -i $tempdir/jellyfin-web.deb
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -27,6 +27,7 @@ ffmpeg_deps=(
     libgcc1
     libgmp10
     libgnutls30
+    libllvm11
     libmp3lame0
     libopus0
     libstdc++6
@@ -37,6 +38,7 @@ ffmpeg_deps=(
     libwebp6
     libwebpmux3
     libx11-6
+    libxcb-randr0
     libzvbi0
     zlib1g
 )

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,12 +5,11 @@
 #=================================================
 
 debian=$(lsb_release --codename --short)
-pkg_version="10.8.0~beta2"
-version=10.8.0-beta2
-# version=$(echo "$pkg_version" | cut -d '-' -f 1)
+pkg_version="10.8.0-1"
+version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
-ffmpeg_pkg_version="5.0.1-3"
-ldap_pkg_version="14.0.0.0"
+ffmpeg_pkg_version="5.0.1-5"
+ldap_pkg_version="15.0.0.0"
 
 architecture=$(dpkg --print-architecture)
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -49,7 +49,7 @@ ynh_script_progression --message="Removing packages..." --weight=1
 
 dpkg --remove jellyfin-web
 dpkg --remove jellyfin-server
-dpkg --remove jellyfin-ffmpeg
+dpkg --remove jellyfin-ffmpeg5
 
 #=================================================
 # REMOVE APP DIRECTORIES


### PR DESCRIPTION
## Problem

- Jellyfin will soon upgrade and I'm afraid this will break a lot of things

## Solution

- Testing a bit before the official release (and the official changelog unfortunately)

DONOTMERGE : This has changes on the .src.default files specific to pre-releases of Jellyfin.
