### PR TITLE
Update to 10.8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Jellyfin enables you to collect, manage, and stream your media. Run the Jellyfin server on your system and gain access to the leading free-software entertainment system, bells and whistles included.
 
 
-**Shipped version:** 10.8.9~ynh1
+**Shipped version:** 10.8.10~ynh1
 
 **Demo:** https://demo.jellyfin.org/stable/web/index.html
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Jellyfin vous permet de collecter, gérer et diffuser vos médias. Exécutez le serveur Jellyfin sur votre système et accédez au principal système de divertissement à logiciel libre.
 
 
-**Version incluse :** 10.8.9~ynh1
+**Version incluse :** 10.8.10~ynh1
 
 **Démo :** https://demo.jellyfin.org/stable/web/index.html
 

--- a/conf/server.bullseye.amd64.src
+++ b/conf/server.bullseye.amd64.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_amd64.deb
-SOURCE_SUM=956f97c53896eae584e738806bb86e1e70ae29a430e2c92693e4a8feea2cd474
+SOURCE_SUM=1d740a2a9603994bd77e77de4dc4097ea40995d77f3b3fdc8766bb2b5a7527ad
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.amd64.src
+++ b/conf/server.bullseye.amd64.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.9/jellyfin-server_10.8.9-1_amd64.deb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_amd64.deb
 SOURCE_SUM=956f97c53896eae584e738806bb86e1e70ae29a430e2c92693e4a8feea2cd474
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb

--- a/conf/server.bullseye.arm64.src
+++ b/conf/server.bullseye.arm64.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_arm64.deb
-SOURCE_SUM=261f0f6780486e307f2fe5fe4e7e9158062752e527ae4805b284c765ac783743
+SOURCE_SUM=52efc80ea71b190081b393696b61fa17e85c28eea9651b3510e933d8ce3004bd
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.bullseye.arm64.src
+++ b/conf/server.bullseye.arm64.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.9/jellyfin-server_10.8.9-1_arm64.deb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_arm64.deb
 SOURCE_SUM=261f0f6780486e307f2fe5fe4e7e9158062752e527ae4805b284c765ac783743
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb

--- a/conf/server.bullseye.armhf.src
+++ b/conf/server.bullseye.armhf.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.9/jellyfin-server_10.8.9-1_armhf.deb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_armhf.deb
 SOURCE_SUM=f6d500e33b3415ed7fad4d3b68b98ef00d23a59155a792a2ed750d8fe012e994
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb

--- a/conf/server.bullseye.armhf.src
+++ b/conf/server.bullseye.armhf.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_armhf.deb
-SOURCE_SUM=f6d500e33b3415ed7fad4d3b68b98ef00d23a59155a792a2ed750d8fe012e994
+SOURCE_SUM=0a2302dbf6a08485774ed5d6877891ed7109ab012b7c803840a0160d82496bb4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.amd64.src
+++ b/conf/server.buster.amd64.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_amd64.deb
-SOURCE_SUM=956f97c53896eae584e738806bb86e1e70ae29a430e2c92693e4a8feea2cd474
+SOURCE_SUM=1d740a2a9603994bd77e77de4dc4097ea40995d77f3b3fdc8766bb2b5a7527ad
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.amd64.src
+++ b/conf/server.buster.amd64.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.9/jellyfin-server_10.8.9-1_amd64.deb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_amd64.deb
 SOURCE_SUM=956f97c53896eae584e738806bb86e1e70ae29a430e2c92693e4a8feea2cd474
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb

--- a/conf/server.buster.arm64.src
+++ b/conf/server.buster.arm64.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_arm64.deb
-SOURCE_SUM=261f0f6780486e307f2fe5fe4e7e9158062752e527ae4805b284c765ac783743
+SOURCE_SUM=52efc80ea71b190081b393696b61fa17e85c28eea9651b3510e933d8ce3004bd
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/server.buster.arm64.src
+++ b/conf/server.buster.arm64.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.9/jellyfin-server_10.8.9-1_arm64.deb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_arm64.deb
 SOURCE_SUM=261f0f6780486e307f2fe5fe4e7e9158062752e527ae4805b284c765ac783743
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb

--- a/conf/server.buster.armhf.src
+++ b/conf/server.buster.armhf.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.9/jellyfin-server_10.8.9-1_armhf.deb
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_armhf.deb
 SOURCE_SUM=f6d500e33b3415ed7fad4d3b68b98ef00d23a59155a792a2ed750d8fe012e994
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb

--- a/conf/server.buster.armhf.src
+++ b/conf/server.buster.armhf.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.10/jellyfin-server_10.8.10-1_armhf.deb
-SOURCE_SUM=f6d500e33b3415ed7fad4d3b68b98ef00d23a59155a792a2ed750d8fe012e994
+SOURCE_SUM=0a2302dbf6a08485774ed5d6877891ed7109ab012b7c803840a0160d82496bb4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.amd64.src
+++ b/conf/web.bullseye.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.9/jellyfin-web_10.8.9-1_all.deb
-SOURCE_SUM=548367401333f08e84f50f61061915feec581c0608500a2e89e618cd245ac302
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.10/jellyfin-web_10.8.10-1_all.deb
+SOURCE_SUM=1e43006c2308bc219bc734fee1f6c48e843921ba7ded09188ca8cfa435ee800f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.arm64.src
+++ b/conf/web.bullseye.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.9/jellyfin-web_10.8.9-1_all.deb
-SOURCE_SUM=548367401333f08e84f50f61061915feec581c0608500a2e89e618cd245ac302
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.10/jellyfin-web_10.8.10-1_all.deb
+SOURCE_SUM=1e43006c2308bc219bc734fee1f6c48e843921ba7ded09188ca8cfa435ee800f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.bullseye.armhf.src
+++ b/conf/web.bullseye.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.9/jellyfin-web_10.8.9-1_all.deb
-SOURCE_SUM=548367401333f08e84f50f61061915feec581c0608500a2e89e618cd245ac302
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.10/jellyfin-web_10.8.10-1_all.deb
+SOURCE_SUM=1e43006c2308bc219bc734fee1f6c48e843921ba7ded09188ca8cfa435ee800f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.amd64.src
+++ b/conf/web.buster.amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.9/jellyfin-web_10.8.9-1_all.deb
-SOURCE_SUM=548367401333f08e84f50f61061915feec581c0608500a2e89e618cd245ac302
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.10/jellyfin-web_10.8.10-1_all.deb
+SOURCE_SUM=1e43006c2308bc219bc734fee1f6c48e843921ba7ded09188ca8cfa435ee800f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.arm64.src
+++ b/conf/web.buster.arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.9/jellyfin-web_10.8.9-1_all.deb
-SOURCE_SUM=548367401333f08e84f50f61061915feec581c0608500a2e89e618cd245ac302
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.10/jellyfin-web_10.8.10-1_all.deb
+SOURCE_SUM=1e43006c2308bc219bc734fee1f6c48e843921ba7ded09188ca8cfa435ee800f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/conf/web.buster.armhf.src
+++ b/conf/web.buster.armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.9/jellyfin-web_10.8.9-1_all.deb
-SOURCE_SUM=548367401333f08e84f50f61061915feec581c0608500a2e89e618cd245ac302
+SOURCE_URL=https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.10/jellyfin-web_10.8.10-1_all.deb
+SOURCE_SUM=1e43006c2308bc219bc734fee1f6c48e843921ba7ded09188ca8cfa435ee800f
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=deb
 SOURCE_IN_SUBDIR=false

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Media System that manage and stream your media",
         "fr": "Système multimédia qui gère et diffuse vos médias"
     },
-    "version": "10.8.9~ynh1",
+    "version": "10.8.10~ynh1",
     "url": "https://jellyfin.org",
     "upstream": {
         "license": "GPL-2.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 debian=$(lsb_release --codename --short)
-pkg_version="10.8.9-1"
+pkg_version="10.8.10-1"
 version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
 ffmpeg_pkg_version="5.1.2-6"


### PR DESCRIPTION
## Problem

- As per the latest release notes: "CRITICAL SECURITY ADVISORY: [GHSA-9p5f-5x8v-x65m](https://github.com/jellyfin/jellyfin/security/advisories/GHSA-9p5f-5x8v-x65m) and [GHSA-89hp-h43h-r5pq](https://github.com/jellyfin/jellyfin-web/security/advisories/GHSA-89hp-h43h-r5pq) can be combined to allow remote code execution for any authenticated Jellyfin user including non-admin users. While the particular execution mechanism of the former dates to the 10.8.0 release, the latter was present for all Jellyfin releases before this point. It is thus absolutely critical for all Jellyfin administrators, regardless of version, to upgrade to this version if they allow any untrusted users and/or expose their instance to the Internet."

## Solution

- This commit upgrades Jellyfin to the latest version (10.8.10) to patch the security issues from upstream.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
