### PR TITLE
Set auth_header = false for SSO

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -220,8 +220,12 @@ then
 	ynh_permission_update --permission="main" --add="visitors"
 fi
 
+# auth_header=false is because Jellyfin expects custom data in the Authorization HTTP header
+# (notably, for Jellyfin Vue)
+ynh_permission_url --permission="main" --auth_header=false
+
 # Only the admin can access the admin panel of the app (if the app has an admin panel)
-ynh_permission_create --permission="admin" --allowed=$admin
+ynh_permission_create --permission="admin" --auth_header=false --allowed=$admin
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -86,8 +86,12 @@ fi
 
 if ! ynh_permission_exists --permission="admin"; then
 	# Create the required permissions
-	ynh_permission_create --permission="admin" --allowed=$admin
+	ynh_permission_create --permission="admin" --auth_header=false --allowed=$admin
 fi
+
+# Update SSO permissions with --auth_header=false (notably, for Jellyfin Vue)
+ynh_permission_url --permission="main" --auth_header=false
+ynh_permission_url --permission="admin" --auth_header=false
 
 # If discovery key does not exist, create it
 if [ -z "$discovery" ]; then


### PR DESCRIPTION
… because Jellyfin expects custom data in the Authorization header.

## Problem

Jellyfin-Vue uses the "newly standard" (?) header Authorization instead of X-Emby-Authorization.

Buuuuut… Yunohost tweaks this header and breaks login.

Talked with @alexAubin about that.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
