### PR TITLE
PLEASE TEST: Upgrade Jellyfin to v10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It shall NOT be edited by hand.
 Jellyfin enables you to collect, manage, and stream your media. Run the Jellyfin server on your system and gain access to the leading free-software entertainment system, bells and whistles included.
 
 
-**Shipped version:** 10.8.13~ynh1
+**Shipped version:** 10.9.1~ynh1
 
 **Demo:** <https://demo.jellyfin.org/stable/web/index.html>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Il NE doit PAS être modifié à la main.
 Jellyfin vous permet de collecter, gérer et diffuser vos médias. Exécutez le serveur Jellyfin sur votre système et accédez au principal système de divertissement à logiciel libre.
 
 
-**Version incluse :** 10.8.13~ynh1
+**Version incluse :** 10.9.1~ynh1
 
 **Démo :** <https://demo.jellyfin.org/stable/web/index.html>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -19,7 +19,7 @@ NON debe editarse manualmente.
 Jellyfin enables you to collect, manage, and stream your media. Run the Jellyfin server on your system and gain access to the leading free-software entertainment system, bells and whistles included.
 
 
-**Versión proporcionada:** 10.8.13~ynh1
+**Versión proporcionada:** 10.9.1~ynh1
 
 **Demo:** <https://demo.jellyfin.org/stable/web/index.html>
 

--- a/README_it.md
+++ b/README_it.md
@@ -19,7 +19,7 @@ NON DEVE essere modificato manualmente.
 Jellyfin enables you to collect, manage, and stream your media. Run the Jellyfin server on your system and gain access to the leading free-software entertainment system, bells and whistles included.
 
 
-**Versione pubblicata:** 10.8.13~ynh1
+**Versione pubblicata:** 10.9.1~ynh1
 
 **Prova:** <https://demo.jellyfin.org/stable/web/index.html>
 

--- a/conf/network.xml
+++ b/conf/network.xml
@@ -1,35 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NetworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <RequireHttps>false</RequireHttps>
-  <CertificatePath />
-  <CertificatePassword />
   <BaseUrl>__PATH__</BaseUrl>
-  <PublicHttpsPort>8920</PublicHttpsPort>
-  <HttpServerPortNumber>__PORT__</HttpServerPortNumber>
-  <HttpsPortNumber>8920</HttpsPortNumber>
+  <InternalHttpPort>__PORT__</InternalHttpPort>
   <EnableHttps>false</EnableHttps>
-  <PublicPort>__PORT__</PublicPort>
-  <UPnPCreateHttpPortMap>false</UPnPCreateHttpPortMap>
-  <UDPPortRange />
   <EnableIPV6>true</EnableIPV6>
   <EnableIPV4>true</EnableIPV4>
-  <EnableSSDPTracing>false</EnableSSDPTracing>
-  <SSDPTracingFilter />
-  <UDPSendCount>2</UDPSendCount>
-  <UDPSendDelay>100</UDPSendDelay>
-  <IgnoreVirtualInterfaces>true</IgnoreVirtualInterfaces>
-  <VirtualInterfaceNames>vEthernet*</VirtualInterfaceNames>
-  <GatewayMonitorPeriod>60</GatewayMonitorPeriod>
-  <TrustAllIP6Interfaces>false</TrustAllIP6Interfaces>
-  <HDHomerunPortRange />
-  <PublishedServerUriBySubnet />
-  <AutoDiscoveryTracing>false</AutoDiscoveryTracing>
   <AutoDiscovery>true</AutoDiscovery>
-  <RemoteIPFilter />
-  <IsRemoteIPFilterBlacklist>false</IsRemoteIPFilterBlacklist>
   <EnableUPnP>true</EnableUPnP>
   <EnableRemoteAccess>true</EnableRemoteAccess>
-  <LocalNetworkSubnets />
-  <LocalNetworkAddresses />
-  <KnownProxies />
+  <LocalNetworkAddresses>
+    <string>127.0.0.1</string>
+  </LocalNetworkAddresses>
 </NetworkConfiguration>

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,0 +1,2 @@
+[Service]
+Environment="JELLYFIN_PublishedServerUrl=https://__DOMAIN____PATH__"

--- a/manifest.toml
+++ b/manifest.toml
@@ -58,24 +58,24 @@ ram.runtime = "100M"
 [resources]
 
     [resources.sources.server_bullseye]
-    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/armhf/jellyfin-server_10.9.1+deb11_armhf.deb"
-    armhf.sha256 = "88a5bd8831468a7fd6f71e2389e99df4951c062e639a788caabdc6aef53d7974"
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/arm64/jellyfin-server_10.9.1+deb11_arm64.deb"
-    arm64.sha256 = "fc61cce35d98ceae8cabc154c891dcd2afc302e82d30eb9bbe9ed8fb4a89129e"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-server_10.9.1+deb11_amd64.deb"
-    amd64.sha256 = "ee855f20090639a214339254de3e4f2cedcbec4d887026dc0c7191209316e556"
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/armhf/jellyfin-server_10.9.2+deb11_armhf.deb"
+    armhf.sha256 = "354dcc1f6e16997d3788b45d714008827e4b2d6d09989cc7b073c3b25903a27e"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/arm64/jellyfin-server_10.9.2+deb11_arm64.deb"
+    arm64.sha256 = "4fbeecd75c6388727a0b30c1949331a3890408bdfebbb417c93a7145add10e88"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-server_10.9.2+deb11_amd64.deb"
+    amd64.sha256 = "590d642ccfde0bbfa68a2283ce51439848f157477c1780bd8a819ff06920398e"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-server.deb"
 
     [resources.sources.server_bookworm]
-    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/armhf/jellyfin-server_10.9.1+deb12_armhf.deb"
-    armhf.sha256 = "fad4963580ae9cdc9cf11b3a05e6b2544e2e5765fec4d7c83d81f65285385171"
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/arm64/jellyfin-server_10.9.1+deb12_arm64.deb"
-    arm64.sha256 = "a7d2b9805833bba01404d594356e91861e78ba63cdff44b02da85a416a49c03b"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-server_10.9.1+deb12_amd64.deb"
-    amd64.sha256 = "be13ab2dab329febb5ff3aa683c6f8f190c86d14e614c5ae4f84560f3504e8b5"
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/armhf/jellyfin-server_10.9.2+deb12_armhf.deb"
+    armhf.sha256 = "c27b8222afd8a75dce8ed33b3e6dd2cc833628c8ef9dd53dfaaf146587e708fd"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/arm64/jellyfin-server_10.9.2+deb12_arm64.deb"
+    arm64.sha256 = "c243996b90a02bd367b5203471082c050cc27b3177a8de22e1f92341ba72463e"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-server_10.9.2+deb12_amd64.deb"
+    amd64.sha256 = "5ec7de506e5ef6d25551a9e11b205947a988af647570f7ee158e98ea495e181b"
 
     format = "whatever"
     extract = false
@@ -83,16 +83,16 @@ ram.runtime = "100M"
 
 
     [resources.sources.web_bullseye]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-web_10.9.1+deb11_all.deb"
-    sha256 = "003f433fa1b18017917b47878a6c31b8d165fd909cd1641092dc41e3909ed209"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-web_10.9.2+deb11_all.deb"
+    sha256 = "276bccdd205e6c1920cbb3ba0953657a66200d14830bf6459a8317cd81eead3a"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-web.deb"
 
     [resources.sources.web_bookworm]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-web_10.9.1+deb12_all.deb"
-    sha256 = "327613691aab0e2448992bb8020fc5481e9438066984189f60f2e8feaf76416d"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-web_10.9.2+deb12_all.deb"
+    sha256 = "cc7a0bfb5c40bd88dc53e6e9abf08ba1d698a362a3de28969a486cce7b369dea"
 
     format = "whatever"
     extract = false

--- a/manifest.toml
+++ b/manifest.toml
@@ -44,7 +44,7 @@ ram.runtime = "100M"
     type = "group"
     default = "visitors"
 
-    [install.admin]
+    [install.init_admin_permission]
     type = "user"
 
     [install.discovery]
@@ -143,6 +143,7 @@ ram.runtime = "100M"
 
     admin.protected = true
     admin.auth_header = false
+    admin.show_tile = false
 
     [resources.ports]
     main.default = 8095

--- a/manifest.toml
+++ b/manifest.toml
@@ -58,24 +58,24 @@ ram.runtime = "100M"
 [resources]
 
     [resources.sources.server_bullseye]
-    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/armhf/jellyfin-server_10.9.2+deb11_armhf.deb"
-    armhf.sha256 = "354dcc1f6e16997d3788b45d714008827e4b2d6d09989cc7b073c3b25903a27e"
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/arm64/jellyfin-server_10.9.2+deb11_arm64.deb"
-    arm64.sha256 = "4fbeecd75c6388727a0b30c1949331a3890408bdfebbb417c93a7145add10e88"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-server_10.9.2+deb11_amd64.deb"
-    amd64.sha256 = "590d642ccfde0bbfa68a2283ce51439848f157477c1780bd8a819ff06920398e"
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/armhf/jellyfin-server_10.9.5+deb11_armhf.deb"
+    armhf.sha256 = "6723d766c92894d1bdf7e30a351fc0bf30749311e43742f9a257d8f12b17466b"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/arm64/jellyfin-server_10.9.5+deb11_arm64.deb"
+    arm64.sha256 = "68c399a2ffbdd2f510d7b44475e6a8e01c0f1afb1912314d94d6ae124eb8bc35"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-server_10.9.5+deb11_amd64.deb"
+    amd64.sha256 = "cb697eb81f2beb7194287ce28115aafadf16618c615e06d1427b068df4392cfa"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-server.deb"
 
     [resources.sources.server_bookworm]
-    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/armhf/jellyfin-server_10.9.2+deb12_armhf.deb"
-    armhf.sha256 = "c27b8222afd8a75dce8ed33b3e6dd2cc833628c8ef9dd53dfaaf146587e708fd"
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/arm64/jellyfin-server_10.9.2+deb12_arm64.deb"
-    arm64.sha256 = "c243996b90a02bd367b5203471082c050cc27b3177a8de22e1f92341ba72463e"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-server_10.9.2+deb12_amd64.deb"
-    amd64.sha256 = "5ec7de506e5ef6d25551a9e11b205947a988af647570f7ee158e98ea495e181b"
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/armhf/jellyfin-server_10.9.5+deb12_armhf.deb"
+    armhf.sha256 = "9ac48b03fe4a47ff9df0643e52ff91eb7ba32d3daa9feda124f1e0ce0c5b14de"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/arm64/jellyfin-server_10.9.5+deb12_arm64.deb"
+    arm64.sha256 = "4c436612664bbc8d0b36a776d8d9146889e000262e3f4e86154b24e266bdbd9b"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-server_10.9.5+deb12_amd64.deb"
+    amd64.sha256 = "629f5260989802330aee542bfc48d8ee0f6026435309b0796c763348c4b107c6"
 
     format = "whatever"
     extract = false
@@ -83,16 +83,16 @@ ram.runtime = "100M"
 
 
     [resources.sources.web_bullseye]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-web_10.9.2+deb11_all.deb"
-    sha256 = "276bccdd205e6c1920cbb3ba0953657a66200d14830bf6459a8317cd81eead3a"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-web_10.9.5+deb11_all.deb"
+    sha256 = "6c3fcd6c53be1b55e43fd12873039b7b08491540ce2769be1c41f101f8abcd13"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-web.deb"
 
     [resources.sources.web_bookworm]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.2/amd64/jellyfin-web_10.9.2+deb12_all.deb"
-    sha256 = "cc7a0bfb5c40bd88dc53e6e9abf08ba1d698a362a3de28969a486cce7b369dea"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-web_10.9.5+deb12_all.deb"
+    sha256 = "475d73ac400d0ec8155c008169c56d4c75d980174255f5fc910b8ac848a17d88"
 
     format = "whatever"
     extract = false
@@ -100,24 +100,24 @@ ram.runtime = "100M"
 
 
     [resources.sources.ffmpeg_bullseye]
-    armhf.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/armhf/jellyfin-ffmpeg6_6.0.1-6-bullseye_armhf.deb"
-    armhf.sha256 = "6f315702413a77d9103ff23963742d508f21fcaeca4c18325defe51eaa9a4380"
-    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/arm64/jellyfin-ffmpeg6_6.0.1-6-bullseye_arm64.deb"
-    arm64.sha256 = "8d11232e36f3dab5defdf4731ca470d51170c423a840d2da0c861d30ea663ff3"
-    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/amd64/jellyfin-ffmpeg6_6.0.1-6-bullseye_amd64.deb"
-    amd64.sha256 = "a678695eeeb92c1fa42bbd665e43d0f3568d211245978b7605019102876c2e8a"
+    armhf.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/armhf/jellyfin-ffmpeg6_6.0.1-7-bullseye_armhf.deb"
+    armhf.sha256 = "4940083aa8bf6f04df7fbd3c5740f96b8b1d41ae2aeef8aba25eed7fbc72dd57"
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/arm64/jellyfin-ffmpeg6_6.0.1-7-bullseye_arm64.deb"
+    arm64.sha256 = "106311dfc45cfa69f9588772b9c0327e1558fd5186f6b4ce6d1f615ad09893bb"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/amd64/jellyfin-ffmpeg6_6.0.1-7-bullseye_amd64.deb"
+    amd64.sha256 = "ee50c84a501c530e179088cf3f6d9048fe446e186d93f726a2073b860a313c5c"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-ffmpeg6.deb"
 
     [resources.sources.ffmpeg_bookworm]
-    armhf.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/armhf/jellyfin-ffmpeg6_6.0.1-6-bookworm_armhf.deb"
-    armhf.sha256 = "7ba482bfdfaff4ed5a11bbbfff17e0aa97d305432a40c0beac2dcdb8fa1468d6"
-    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/arm64/jellyfin-ffmpeg6_6.0.1-6-bookworm_arm64.deb"
-    arm64.sha256 = "c54657f94247bb082fa04ec2e9ab3d68a8ae8d4ff879f52a4cea18f073cdf3ba"
-    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/amd64/jellyfin-ffmpeg6_6.0.1-6-bookworm_amd64.deb"
-    amd64.sha256 = "92d859895f7cb2f6428fe7e1299ce14959948a1e48a0b22a339c17f66970c45e"
+    armhf.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/armhf/jellyfin-ffmpeg6_6.0.1-7-bookworm_armhf.deb"
+    armhf.sha256 = "03d8a5512c7406e77359475da729157fc653dc5203f2399b59c71c6f59ca10f3"
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/arm64/jellyfin-ffmpeg6_6.0.1-7-bookworm_arm64.deb"
+    arm64.sha256 = "6c21dfdd931c576fcd5c095d4aae2cf92d4720beba6c73404f3d56220213c2a4"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/amd64/jellyfin-ffmpeg6_6.0.1-7-bookworm_amd64.deb"
+    amd64.sha256 = "0773fda9111e03394e088790eabc99dbb0291d107a4950bdcbfafd94c5d0652e"
 
     format = "whatever"
     extract = false

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin"
 description.en = "Media System that manage and stream your media"
 description.fr = "Système multimédia qui gère et diffuse vos médias"
 
-version = "10.9.1~ynh1"
+version = "10.9.6~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -58,24 +58,24 @@ ram.runtime = "100M"
 [resources]
 
     [resources.sources.server_bullseye]
-    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/armhf/jellyfin-server_10.9.5+deb11_armhf.deb"
-    armhf.sha256 = "6723d766c92894d1bdf7e30a351fc0bf30749311e43742f9a257d8f12b17466b"
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/arm64/jellyfin-server_10.9.5+deb11_arm64.deb"
-    arm64.sha256 = "68c399a2ffbdd2f510d7b44475e6a8e01c0f1afb1912314d94d6ae124eb8bc35"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-server_10.9.5+deb11_amd64.deb"
-    amd64.sha256 = "cb697eb81f2beb7194287ce28115aafadf16618c615e06d1427b068df4392cfa"
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/armhf/jellyfin-server_10.9.6+deb11_armhf.deb"
+    armhf.sha256 = "aaadbda9350db388b7e96427e640dcce0821c8241f23bba1f1587ee642ca05f1"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/arm64/jellyfin-server_10.9.6+deb11_arm64.deb"
+    arm64.sha256 = "bf0dc1239fff35aa03582b78c4371dd5e96422ead43bf24fa8b0527fcca64b3f"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/amd64/jellyfin-server_10.9.6+deb11_amd64.deb"
+    amd64.sha256 = "ec5d745f6e140d1ed1795c36276f695fe96c295396db475b85bdce54f29d9506"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-server.deb"
 
     [resources.sources.server_bookworm]
-    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/armhf/jellyfin-server_10.9.5+deb12_armhf.deb"
-    armhf.sha256 = "9ac48b03fe4a47ff9df0643e52ff91eb7ba32d3daa9feda124f1e0ce0c5b14de"
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/arm64/jellyfin-server_10.9.5+deb12_arm64.deb"
-    arm64.sha256 = "4c436612664bbc8d0b36a776d8d9146889e000262e3f4e86154b24e266bdbd9b"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-server_10.9.5+deb12_amd64.deb"
-    amd64.sha256 = "629f5260989802330aee542bfc48d8ee0f6026435309b0796c763348c4b107c6"
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/armhf/jellyfin-server_10.9.6+deb12_armhf.deb"
+    armhf.sha256 = "2666666e66e7c736b47723d911c85807154fb277a7da46ea9bd12cfbb474a2ea"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/arm64/jellyfin-server_10.9.6+deb12_arm64.deb"
+    arm64.sha256 = "7ef1d9c347619e59af7d71e97c762031f6c24680a035f54964f34a2042103c1f"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/amd64/jellyfin-server_10.9.6+deb12_amd64.deb"
+    amd64.sha256 = "eafe4e19ee2a99bfb98c9de11e367f0d2313cd585332efe8cd1468e132221181"
 
     format = "whatever"
     extract = false
@@ -83,16 +83,16 @@ ram.runtime = "100M"
 
 
     [resources.sources.web_bullseye]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-web_10.9.5+deb11_all.deb"
-    sha256 = "6c3fcd6c53be1b55e43fd12873039b7b08491540ce2769be1c41f101f8abcd13"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/amd64/jellyfin-web_10.9.6+deb11_all.deb"
+    sha256 = "ea469e302a19db6bfc1ac5001adeb5f278e9c02b52cb6752000345a4a7392416"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-web.deb"
 
     [resources.sources.web_bookworm]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.5/amd64/jellyfin-web_10.9.5+deb12_all.deb"
-    sha256 = "475d73ac400d0ec8155c008169c56d4c75d980174255f5fc910b8ac848a17d88"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.6/amd64/jellyfin-web_10.9.6+deb12_all.deb"
+    sha256 = "7324d204b5c050a3d85e10861c6923366fa9c17b21ed8cd6420b07363c0d1f5f"
 
     format = "whatever"
     extract = false

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin"
 description.en = "Media System that manage and stream your media"
 description.fr = "Système multimédia qui gère et diffuse vos médias"
 
-version = "10.8.13~ynh1"
+version = "10.9.1~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -56,78 +56,77 @@ ram.runtime = "100M"
     default = true
 
 [resources]
-    [resources.sources]
-    [resources.sources.server]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_armhf.deb"
-    armhf.sha256 = "ee4588aeeb55282b044d3bb4efef146a43abd742d3ef9327e042b2959008dc60"
 
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_arm64.deb"
-    arm64.sha256 = "b9b917ec6ed4ddd3c728cb7be84245ff625c0a7ae12653a921cb3a9f6149252d"
+    [resources.sources.server_bullseye]
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/armhf/jellyfin-server_10.9.1+deb11_armhf.deb"
+    armhf.sha256 = "88a5bd8831468a7fd6f71e2389e99df4951c062e639a788caabdc6aef53d7974"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/arm64/jellyfin-server_10.9.1+deb11_arm64.deb"
+    arm64.sha256 = "fc61cce35d98ceae8cabc154c891dcd2afc302e82d30eb9bbe9ed8fb4a89129e"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-server_10.9.1+deb11_amd64.deb"
+    amd64.sha256 = "ee855f20090639a214339254de3e4f2cedcbec4d887026dc0c7191209316e556"
 
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_amd64.deb"
-    amd64.sha256 = "d54decc098d5e61be50847edba8722d6468e22134bae2df514859e064eb8d727"
-
+    format = "whatever"
+    extract = false
     rename = "jellyfin-server.deb"
+
+    [resources.sources.server_bookworm]
+    armhf.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/armhf/jellyfin-server_10.9.1+deb12_armhf.deb"
+    armhf.sha256 = "fad4963580ae9cdc9cf11b3a05e6b2544e2e5765fec4d7c83d81f65285385171"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/arm64/jellyfin-server_10.9.1+deb12_arm64.deb"
+    arm64.sha256 = "a7d2b9805833bba01404d594356e91861e78ba63cdff44b02da85a416a49c03b"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-server_10.9.1+deb12_amd64.deb"
+    amd64.sha256 = "be13ab2dab329febb5ff3aa683c6f8f190c86d14e614c5ae4f84560f3504e8b5"
+
     format = "whatever"
     extract = false
+    rename = "jellyfin-server.deb"
 
-    [resources.sources.web]
-    url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.13/jellyfin-web_10.8.13-1_all.deb"
-    sha256 = "8a30e2239f97d1d749f6059db0ff1e4189f44babfb9b0cf236102b7c95b0babe"
 
+    [resources.sources.web_bullseye]
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-web_10.9.1+deb11_all.deb"
+    sha256 = "003f433fa1b18017917b47878a6c31b8d165fd909cd1641092dc41e3909ed209"
+
+    format = "whatever"
+    extract = false
     rename = "jellyfin-web.deb"
+
+    [resources.sources.web_bookworm]
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.9.1/amd64/jellyfin-web_10.9.1+deb12_all.deb"
+    sha256 = "327613691aab0e2448992bb8020fc5481e9438066984189f60f2e8feaf76416d"
+
     format = "whatever"
     extract = false
-
-
-    [resources.sources.ffmpeg_bookworm]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_armhf.deb"
-    armhf.sha256 = "bdb28e67fa4dc8e321366c4a19e18bcc6166a60d6aa5a4bf2da1263489b4f25f"
-
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_arm64.deb"
-    arm64.sha256 = "aabf62104399f242ddb7b8c2e308976f6b233ceac5ffccbabd340a28e428ca3c"
-
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_amd64.deb"
-    amd64.sha256 = "cb40c04e026d83b9265535e214f883d4a26824b5703304064fd38fffa70ac449"
-
-    rename = "jellyfin-ffmpeg6.deb"
-    format = "whatever"
-    extract = false
+    rename = "jellyfin-web.deb"
 
 
     [resources.sources.ffmpeg_bullseye]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_armhf.deb"
-    armhf.sha256 = "700bab9e8c96594f83d731019cdbc20fbab303c1d8440288e463e372cd16ed7a"
+    armhf.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/armhf/jellyfin-ffmpeg6_6.0.1-6-bullseye_armhf.deb"
+    armhf.sha256 = "6f315702413a77d9103ff23963742d508f21fcaeca4c18325defe51eaa9a4380"
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/arm64/jellyfin-ffmpeg6_6.0.1-6-bullseye_arm64.deb"
+    arm64.sha256 = "8d11232e36f3dab5defdf4731ca470d51170c423a840d2da0c861d30ea663ff3"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/amd64/jellyfin-ffmpeg6_6.0.1-6-bullseye_amd64.deb"
+    amd64.sha256 = "a678695eeeb92c1fa42bbd665e43d0f3568d211245978b7605019102876c2e8a"
 
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_arm64.deb"
-    arm64.sha256 = "56ef93f285e922417cda98b109021be614a5307d9d7c18aff22fa0c439ab77b5"
-
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_amd64.deb"
-    amd64.sha256 = "50b0cbd2cd0ab64fd6803d2bdfd15946ec6f80c0b492f81ad85e921ffafdcf7e"
-
-    rename = "jellyfin-ffmpeg6.deb"
     format = "whatever"
     extract = false
-
-
-    [resources.sources.ffmpeg_buster]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_armhf.deb"
-    armhf.sha256 = "6f3beae72aec030aae96dc044bfcf736f12fc135cc574cde8085609e47374a43"
-
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_arm64.deb"
-    arm64.sha256 = "109ea41f17e314e3e9b32689844841ddd54a600419ff89e0e979e195a25b91c5"
-
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_amd64.deb"
-    amd64.sha256 = "a1c55b7f439f2b9a487ea90341a280467f1973fcd12607f08bcd16cf22ce307a"
-    
     rename = "jellyfin-ffmpeg6.deb"
+
+    [resources.sources.ffmpeg_bookworm]
+    armhf.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/armhf/jellyfin-ffmpeg6_6.0.1-6-bookworm_armhf.deb"
+    armhf.sha256 = "7ba482bfdfaff4ed5a11bbbfff17e0aa97d305432a40c0beac2dcdb8fa1468d6"
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/arm64/jellyfin-ffmpeg6_6.0.1-6-bookworm_arm64.deb"
+    arm64.sha256 = "c54657f94247bb082fa04ec2e9ab3d68a8ae8d4ff879f52a4cea18f073cdf3ba"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/latest-6.x/amd64/jellyfin-ffmpeg6_6.0.1-6-bookworm_amd64.deb"
+    amd64.sha256 = "92d859895f7cb2f6428fe7e1299ce14959948a1e48a0b22a339c17f66970c45e"
+
     format = "whatever"
     extract = false
+    rename = "jellyfin-ffmpeg6.deb"
 
 
     [resources.sources.plugin_ldap]
-    url = "https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_17.0.0.0.zip"
-    sha256 = "042bdd16950c7569c154311cc64af49c7d6096e9b0a7184287707d5ee317ecf5"
+    url = "https://repo.jellyfin.org/files/plugin/ldap-authentication/ldap-authentication_19.0.0.0.zip"
+    sha256 = "3b8366f670484c9ab1ece826667754b69736d910d9ccde90c105a67ba441ead9"
     in_subdir = false
 
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -146,5 +146,12 @@ ram.runtime = "100M"
 
     [resources.ports]
     main.default = 8095
+    # If we ever want to automatically expose the discovery ports without a setting
+    # servicediscovery.default = 1900
+    # servicediscovery.exposed = "UDP"
+    # servicediscovery.fixed = true
+    # clientdiscovery.default = 7359
+    # clientdiscovery.exposed = "UDP"
+    # clientdiscovery.fixed = true
 
     [resources.apt]

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 debian=$(lsb_release --codename --short)
 debian_number=$(lsb_release --release --short)
-pkg_version="10.9.5"
+pkg_version="10.9.6"
 version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
 ffmpeg_pkg_version="6.0.1-7"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 debian=$(lsb_release --codename --short)
 debian_number=$(lsb_release --release --short)
-pkg_version="10.9.1"
+pkg_version="10.9.2"
 version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
 ffmpeg_pkg_version="6.0.1-6"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,10 +6,10 @@
 
 debian=$(lsb_release --codename --short)
 debian_number=$(lsb_release --release --short)
-pkg_version="10.9.2"
+pkg_version="10.9.5"
 version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
-ffmpeg_pkg_version="6.0.1-6"
+ffmpeg_pkg_version="6.0.1-7"
 
 # "targetAbi" line in plugin's meta.json, to check for outdated plugins
 plugin_abi="10.9.0.0"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -65,11 +65,39 @@ install_jellyfin_packages() {
 	apt-mark auto jellyfin-server jellyfin-web jellyfin-ffmpeg6
 }
 
-open_jellyfin_discovery_ports() {
+configure_jellyfin_discovery_ports() {
+	case $1 in
+		"install")
+			install_jellyfin_discovery_ports
+			;;
+		"remove")
+			remove_jellyfin_discovery_ports
+			;;
+		*)
+			ynh_print_warn --message="Invalid script calling configure_jellyfin_discovery_ports with args (should be install|remove): $@"
+			;;
+	esac
+}
+
+remove_jellyfin_discovery_ports() {
+	if [[ $discovery_service -eq 1 ]] && yunohost firewall list | grep -q "\- $discovery_service_port$"
+then
+	ynh_exec_warn_less yunohost firewall disallow UDP $discovery_service_port
+fi
+
+if [[ $discovery_client -eq 1 ]] && yunohost firewall list | grep -q "\- $discovery_client_port$"
+then
+	ynh_exec_warn_less yunohost firewall disallow UDP $discovery_client_port
+fi
+
+}
+
+install_jellyfin_discovery_ports() {
 	discovery_service=$discovery
 	discovery_client=$discovery
 
 	if [ "$discovery" -eq 1 ]; then
+		opened_ports=($discovery_service_port $discovery_client_port)
 
 		# Open port $discovery_service_port for service auto-discovery
 		if ynh_port_available --port=$discovery_service_port; then

--- a/scripts/install
+++ b/scripts/install
@@ -69,6 +69,7 @@ ynh_add_config --template="logging.json" --destination="$config_path/logging.jso
 ynh_script_progression --message="Installing LDAP plugin..." --weight=2
 
 ynh_setup_source --dest_dir="/var/lib/jellyfin/plugins/LDAP Authentication" --source_id=plugin_ldap
+
 mkdir -p /var/lib/jellyfin/plugins/configurations/
 ynh_add_config --template="LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
 
@@ -110,6 +111,12 @@ yunohost service add "$app" --description="Jellyfin media center"
 
 # Only the admin can access the admin panel of the app (if the app has an admin panel)
 ynh_permission_update --permission="admin" --add="$admin"
+
+#=================================================
+# EDIT SYSTEMD ENVIRONMENT VARIABLE FOR AUTO-DISCOVERY
+#=================================================
+ynh_add_config --template="systemd.service" --destination="/etc/systemd/system/jellyfin.service.d/baseurl.service.conf"
+systemctl daemon-reload
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/install
+++ b/scripts/install
@@ -106,12 +106,12 @@ ynh_use_logrotate
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
 ports_args=()
-if [[ "${opened_ports:-__NOTHING__}" = "__NOTHING__" ]]; then
-	ports_args+=('--open-ports')
-	ports_args+=(${ports})
+if [[ "${opened_ports:-__NOTHING__}" != "__NOTHING__" ]]; then
+	ports_args+=('--needs_exposed_ports')
+	ports_args+=(${opened_ports})
 fi
 
-yunohost service add "$app" --description="Jellyfin media center" "${ports_args[@]}"
+yunohost service add "$app" --description="Jellyfin media center" ${ports_args[@]}
 
 #=================================================
 # EDIT SYSTEMD ENVIRONMENT VARIABLE FOR AUTO-DISCOVERY

--- a/scripts/install
+++ b/scripts/install
@@ -113,9 +113,6 @@ fi
 
 yunohost service add "$app" --description="Jellyfin media center" "${ports_args[@]}"
 
-# Only the admin can access the admin panel of the app (if the app has an admin panel)
-ynh_permission_update --permission="admin" --add="$admin"
-
 #=================================================
 # EDIT SYSTEMD ENVIRONMENT VARIABLE FOR AUTO-DISCOVERY
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -23,10 +23,8 @@ ynh_app_setting_set --app="$app" --key=config_path --value="$config_path"
 #=================================================
 # OPEN PORTS
 #=================================================
-
-ynh_script_progression --message="Configuring firewall..." --weight=1
-
-open_jellyfin_discovery_ports
+ynh_script_progression --message="Checking whether to open ports..." --weight=1
+configure_jellyfin_discovery_ports install
 
 #=================================================
 # INSTALL PACKAGES
@@ -107,7 +105,13 @@ ynh_use_logrotate
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add "$app" --description="Jellyfin media center"
+ports_args=()
+if [[ "${opened_ports:-__NOTHING__}" = "__NOTHING__" ]]; then
+	ports_args+=('--open-ports')
+	ports_args+=(${ports})
+fi
+
+yunohost service add "$app" --description="Jellyfin media center" "${ports_args[@]}"
 
 # Only the admin can access the admin panel of the app (if the app has an admin panel)
 ynh_permission_update --permission="admin" --add="$admin"

--- a/scripts/remove
+++ b/scripts/remove
@@ -41,18 +41,8 @@ ynh_remove_app_dependencies
 #=================================================
 # CLOSE A PORT
 #=================================================
-
-if [[ $discovery_service -eq 1 ]] && yunohost firewall list | grep -q "\- $discovery_service_port$"
-then
-	ynh_script_progression --message="Closing port $discovery_service_port..." --weight=1
-	ynh_exec_warn_less yunohost firewall disallow UDP $discovery_service_port
-fi
-
-if [[ $discovery_client -eq 1 ]] && yunohost firewall list | grep -q "\- $discovery_client_port$"
-then
-	ynh_script_progression --message="Closing port $discovery_client_port..." --weight=1
-	ynh_exec_warn_less yunohost firewall disallow UDP $discovery_client_port
-fi
+ynh_script_progression --message="Checking whether to open ports..." --weight=1
+configure_jellyfin_discovery_ports remove
 
 #=================================================
 # SPECIFIC REMOVE

--- a/scripts/restore
+++ b/scripts/restore
@@ -18,7 +18,6 @@ source /usr/share/yunohost/helpers
 ynh_script_progression --message="Reconfiguring the dedicated system user..." --weight=1
 
 # It could be created later by the deb, but it's cleaner here
-ynh_system_user_create --username=$app
 if getent group render && ! id -Gn "$app" | grep -qw "\brender\b" >/dev/null; then
 	# Add user to render group
 	adduser $app render

--- a/scripts/restore
+++ b/scripts/restore
@@ -27,9 +27,8 @@ fi
 #=================================================
 # OPEN PORTS
 #=================================================
-ynh_script_progression --message="Configuring firewall..." --weight=1
-
-open_jellyfin_discovery_ports
+ynh_script_progression --message="Checking whether to open ports..." --weight=1
+configure_jellyfin_discovery_ports install
 
 #=================================================
 # RESTORE THE APP MAIN DIR
@@ -93,7 +92,15 @@ ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add $app --description="Jellyfin media center"
+ports_args=()
+if [[ "${opened_ports:-__NOTHING__}" = "__NOTHING__" ]]; then
+	ports_args+=('--open-ports')
+	ports_args+=(${ports})
+fi
+
+yunohost service add "$app" --description="Jellyfin media center" "${ports_args[@]}"
+
+
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
-from typing import Any
+from typing import Any, Tuple, Dict, Optional, List
 from pathlib import Path
+import hashlib
 import tomlkit
 import requests
 
 REPO_ROOT = Path(__file__).parent.parent
 
 JELLYFIN_REPO = "https://repo.jellyfin.org"
-JELLYFIN_DEB_REPO = f"{JELLYFIN_REPO}/releases/server/debian"
 
 ARCHS = [
     "armhf",
@@ -16,45 +16,95 @@ ARCHS = [
     "amd64",
 ]
 
-DEBS = [
-    "buster",
-    "bullseye",
-    "bookworm",
-]
+DEBS = {
+    "bullseye": "11",
+    "bookworm": "12",
+}
 
+class JellyfinDistro:
+    def __init__(self, debian_number: str, debian_name: str, arch: List[str]):
+        self.debian_number = debian_number
+        self.debian_name = debian_name
+        self.arch = arch
+
+    # Version in form of 10.9.0-2
+    def server_url(self, version: str, arch: str) -> str:
+        return f"{JELLYFIN_REPO}/files/server/debian/stable/v{version}/{arch}/jellyfin-server_{version}+deb{self.debian_number}_{arch}.deb"
+
+    def web_url(self, version: str) -> str:
+        return f"{JELLYFIN_REPO}/files/server/debian/stable/v{version}/amd64/jellyfin-web_{version}+deb{self.debian_number}_all.deb"
+
+    def ffmpeg_url(self, version: str, arch: str) -> str:
+        return f"{JELLYFIN_REPO}/files/ffmpeg/debian/latest-6.x/{arch}/jellyfin-ffmpeg6_{version}-{self.debian_name}_{arch}.deb"
+
+    def ldap_url(self, version: str) -> str:
+        return f"{JELLYFIN_REPO}/files/plugin/ldap-authentication/ldap-authentication_{version}.zip"
+
+    def update_package(self, manifest: Dict, package: str, version: str):
+        url = None
+        urls = {}
+        if package == "server":
+            for arch in self.arch: urls[arch] = self.server_url(version, arch)
+            key = f"server_{self.debian_name}"
+            extra = { "format": "whatever", "extract": False, "rename": "jellyfin-server.deb" }
+        elif package == "web":
+            url = self.web_url(version)
+            key = f"web_{self.debian_name}"
+            extra = { "format": "whatever", "extract": False, "rename": "jellyfin-web.deb" }
+        elif package == "ffmpeg":
+            for arch in self.arch: urls[arch] = self.ffmpeg_url(version, arch)
+            key = f"ffmpeg_{self.debian_name}"
+            extra = { "format": "whatever", "extract": False, "rename": "jellyfin-ffmpeg6.deb" }
+        elif package == "ldap":
+            url = self.ldap_url(version)
+            key = "plugin_ldap"
+            extra = {"in_subdir": False}
+        else: raise Exception(f"Wrong jellyfin package: {package}")
+
+        if key not in manifest["resources"]["sources"]:
+            manifest["resources"]["sources"][key] = {}
+
+        # Single URL, not per arch
+        if url:
+            print(f"Checking for updates for Jellyfin's {package} (distro={self.debian_name}) to version {version}")
+            self.update_package_helper(manifest["resources"]["sources"][key], package, version, url)
+        else:
+            # Different URL per architecture
+            for arch, url in urls.items():
+                if arch not in manifest["resources"]["sources"][key]:
+                    manifest["resources"]["sources"][key][arch] = {}
+                print(f"Checking for updates for Jellyfin's {package} (arch={arch},distro={self.debian_name}) to version {version}")
+                self.update_package_helper(manifest["resources"]["sources"][key][arch], package, version, url)
+
+        # Add extra settings
+        for k, v in extra.items():
+            manifest["resources"]["sources"][key][k] = v
+
+    def update_package_helper(self, entry: Dict, package: str, version: str, url: str):
+        # Assume version changed only if URL changed
+        if "url" in entry and entry["url"] == url:
+            print(f"    Already at version {version} in manifest.toml.")
+            return
+
+        sha = sha256sum_of(url)
+        entry["url"] = url
+        entry["sha256"] = sha
+        print(f"    Updated to version {version}.")
 
 def version_from__common_sh(name: str) -> str:
     content = (REPO_ROOT/"scripts"/"_common.sh").open(encoding="utf-8").readlines()
     result = next(filter(lambda line: line.startswith(f"{name}="), content))
     return result.split('"')[1]
 
-
-def server_url(arch: str, version: str) -> str:
-    version_simple = version.split("-")[0]
-    return f"{JELLYFIN_DEB_REPO}/versions/stable/server/{version_simple}/jellyfin-server_{version}_{arch}.deb"
-
-
-def web_url(arch: str, version: str) -> str:
-    version_simple = version.split("-")[0]
-    return f"{JELLYFIN_DEB_REPO}/versions/stable/web/{version_simple}/jellyfin-web_{version}_all.deb"
-
-
-def ffmpeg_url(arch: str, deb: str, version: str) -> str:
-    major = version.split(".")[0]
-    return f"{JELLYFIN_DEB_REPO}/versions/jellyfin-ffmpeg/{version}/jellyfin-ffmpeg{major}_{version}-{deb}_{arch}.deb"
-
-
-def ldap_url(arch: str, version: str) -> str:
-    major = version.split(".")[0]
-    return f"{JELLYFIN_REPO}/releases/plugin/ldap-authentication/ldap-authentication_{version}.zip"
-
-
 def sha256sum_of(url: str) -> str:
-    result = requests.get(f"{url}.sha256sum", timeout=10)
+    # No more sha256sum files provided on release repo?
+    result = requests.get(url, timeout=10)
+    if result.status_code != 200 and not (result.status_code > 300 and result.status_code < 400):
+        raise Exception(f"Wrong status code on URL {url}: {result.status_code}")
 
-    content = result.content.decode("utf-8")
-    return content.split(" ")[0]
-
+    hasher = hashlib.sha256()
+    hasher.update(result.content)
+    return hasher.hexdigest()
 
 def main() -> None:
     manifest_file = REPO_ROOT/"manifest.toml"
@@ -64,27 +114,14 @@ def main() -> None:
     ffmpeg_version = version_from__common_sh("ffmpeg_pkg_version")
     ldap_version = version_from__common_sh("ldap_pkg_version")
 
-    for arch in ARCHS:
-        url = server_url(arch, jellyfin_version)
-        manifest["resources"]["sources"]["server"][arch]["url"] = url
-        manifest["resources"]["sources"]["server"][arch]["sha256"] = sha256sum_of(url)
-
-    url = web_url(arch, jellyfin_version)
-    manifest["resources"]["sources"]["web"]["url"] = url
-    manifest["resources"]["sources"]["web"]["sha256"] = sha256sum_of(url)
-
-    for arch in ARCHS:
-        for deb in DEBS:
-            url = ffmpeg_url(arch, deb, ffmpeg_version)
-            manifest["resources"]["sources"][f"ffmpeg_{deb}"][arch]["url"] = url
-            manifest["resources"]["sources"][f"ffmpeg_{deb}"][arch]["sha256"] = sha256sum_of(url)
-
-    url = ldap_url(arch, ldap_version)
-    manifest["resources"]["sources"]["plugin_ldap"]["url"] = url
-    manifest["resources"]["sources"]["plugin_ldap"]["sha256"] = sha256sum_of(url)
+    for debian_name, debian_number in DEBS.items():
+        jellyfin = JellyfinDistro(debian_number, debian_name, ARCHS)
+        jellyfin.update_package(manifest, "server", jellyfin_version)
+        jellyfin.update_package(manifest, "web", jellyfin_version)
+        jellyfin.update_package(manifest, "ffmpeg", ffmpeg_version)
+        jellyfin.update_package(manifest, "ldap", ldap_version)
 
     manifest_file.open("w", encoding="utf-8").write(tomlkit.dumps(manifest))
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -92,14 +92,6 @@ for name in system.xml network.xml logging.json; do
 	cp "$config_path/$name" "$bakdir/$name"
 done
 
-# ynh_package_install passes --no-remove so the ffmpeg5 -> ffmpeg6 migration is blocked.
-# So we remove the packages before installing the new ones.
-if ynh_package_is_installed "jellyfin-ffmpeg5"; then
-	# Previous versions of the package did not do that so remove_app_dependencies doesn't do its job
-	apt-mark auto jellyfin-server jellyfin-web jellyfin-ffmpeg5
-	# ynh_remove_app_dependencies
-fi
-
 install_jellyfin_packages
 
 #=================================================
@@ -123,17 +115,44 @@ for name in system.xml network.xml logging.json; do
 done
 ynh_secure_remove "$bakdir"
 
-# TODO: investigate if we can avoid overriding system.xml
-#ynh_add_config --template="system.xml" --destination="$config_path/system.xml"
 ynh_add_config --template="network.xml" --destination="$config_path/network.xml"
 ynh_add_config --template="logging.json" --destination="$config_path/logging.json"
+
+#=================================================
+# ENSURE NO OLD/INCOMPATIBLE PLUGINS ARE LEFT
+#=================================================
+shopt -s nullglob
+mkdir -p /var/lib/jellyfin/plugins-backup
+
+if [ -d /var/lib/jellyfin/plugins ]; then
+	for directory in /var/lib/jellyfin/plugins/*; do
+		if [[ "$(basename "$directory")" = "configurations" ]]; then
+			# Kepe plugin config
+			continue
+		fi
+
+		if [ ! -f "$directory"/meta.json ]; then
+			mv "$directory" /var/lib/jellyfin/plugins-backup/
+		fi
+
+		# Jellyfin doesn't refuse to start with old plugins. It just does weird
+		# things such as https://github.com/jellyfin/jellyfin-plugin-ldapauth/issues/161
+		# As a precaution, move older ABI plugins to another folder so things don't break
+		abi="$(jq -r '.targetAbi' "$directory"/meta.json)"
+		if [[ "$abi" != "$plugin_abi" ]]; then
+			name="$(basename "$directory")"
+			ynh_print_warn --message="Jellyfin plugin '$name' has different ABI version $abi than expected $plugin_abi. Moving to /var/lib/jellyfin/plugins-backup."
+			mv "$directory" /var/lib/jellyfin/plugins-backup/
+		fi
+	done
+fi
 
 #=================================================
 # INSTALL LDAP PLUGIN
 #=================================================
 ynh_script_progression --message="Installing LDAP plugin..." --weight=2
 
-ynh_setup_source --dest_dir="/var/lib/jellyfin/plugins/LDAP Authentication" --source_id=plugin_ldap
+ynh_setup_source --full_replace=1 --dest_dir="/var/lib/jellyfin/plugins/LDAP Authentication" --source_id=plugin_ldap
 mkdir -p /var/lib/jellyfin/plugins/configurations/
 ynh_add_config --template="LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
 
@@ -163,7 +182,7 @@ ynh_multimedia_addaccess $app
 ynh_script_progression --message="Upgrading logrotate configuration..." --weight=1
 
 # Use logrotate to manage app-specific logfile(s)
-ynh_use_logrotate --non-append
+ynh_use_logrotate
 
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST
@@ -173,11 +192,17 @@ ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 yunohost service add $app --description="Jellyfin media center"
 
 #=================================================
+# EDIT SYSTEMD ENVIRONMENT VARIABLE FOR AUTO-DISCOVERY
+#=================================================
+ynh_add_config --template="systemd.service" --destination="/etc/systemd/system/jellyfin.service.d/baseurl.service.conf"
+systemctl daemon-reload
+
+#=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --timeout=15
+ynh_systemd_action --service_name=$app --action="restart" --log_path="systemd" --timeout=15
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -55,31 +55,11 @@ if [ ! -f "/etc/logrotate.d/$app" ]; then
 	ynh_use_logrotate
 fi
 
-discovery_service=$discovery
-discovery_client=$discovery
-
-if [ $discovery -eq 1 ]; then
-	ynh_script_progression --message="Configuring firewall..." --weight=1
-
-	# Open port $discovery_service_port for service auto-discovery
-	if ynh_port_available --port=$discovery_service_port; then
-		ynh_exec_warn_less yunohost firewall allow UDP $discovery_service_port
-	else
-		discovery_service=0
-		ynh_print_warn --message="Port $discovery_service_port (for service auto-discovery) is not available. Continuing nonetheless."
-	fi
-
-	# Open port $discovery_client_port for client auto-discovery
-	if ynh_port_available --port=$discovery_client_port; then
-		ynh_exec_warn_less yunohost firewall allow UDP $discovery_client_port
-	else
-		discovery_client=0
-		ynh_print_warn --message="Port $discovery_client_port (for client auto-discovery) is not available. Continuing nonetheless."
-	fi
-fi
-
-ynh_app_setting_set --app=$app --key=discovery_service --value=$discovery_service
-ynh_app_setting_set --app=$app --key=discovery_client --value=$discovery_client
+#=================================================
+# OPEN PORTS
+#=================================================
+ynh_script_progression --message="Checking whether to open ports..." --weight=1
+configure_jellyfin_discovery_ports install
 
 #=================================================
 # UPGRADE PACKAGES
@@ -189,7 +169,13 @@ ynh_use_logrotate
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add $app --description="Jellyfin media center"
+ports_args=()
+if [[ "${opened_ports:-__NOTHING__}" = "__NOTHING__" ]]; then
+	ports_args+=('--open-ports')
+	ports_args+=(${ports})
+fi
+
+yunohost service add "$app" --description="Jellyfin media center" "${ports_args[@]}"
 
 #=================================================
 # EDIT SYSTEMD ENVIRONMENT VARIABLE FOR AUTO-DISCOVERY

--- a/tests.toml
+++ b/tests.toml
@@ -9,6 +9,7 @@ test_format = 1.0
     """
 
     args.admin = "john"
+    args.init_admin_permission="john"
 
     test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.name = "10.8.13_ynh1"
     test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.args.domain = "domain.tld"

--- a/tests.toml
+++ b/tests.toml
@@ -8,9 +8,9 @@ test_format = 1.0
     sudo apt update >/dev/null
     """
 
-    args.admin = "john"
-    args.init_admin_permission="john"
+    args.admin = "package_checker"
+    args.init_admin_permission="package_checker"
 
     test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.name = "10.8.13_ynh1"
     test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.args.domain = "domain.tld"
-    test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.args.admin = "john"
+    test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.args.admin = "package_checker"

--- a/tests.toml
+++ b/tests.toml
@@ -10,6 +10,6 @@ test_format = 1.0
 
     args.admin = "john"
 
-    test_upgrade_from.384dcd2ff1dbf4b0085edb7f12e4d15f00508e2b.name = "10.8.0_ynh1"
-    test_upgrade_from.384dcd2ff1dbf4b0085edb7f12e4d15f00508e2b.args.domain = "domain.tld"
-    test_upgrade_from.384dcd2ff1dbf4b0085edb7f12e4d15f00508e2b.args.admin = "john"
+    test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.name = "10.8.13_ynh1"
+    test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.args.domain = "domain.tld"
+    test_upgrade_from.c78bd4fc24803f23b1d243f397f3128d8fe663d8.args.admin = "john"


### PR DESCRIPTION
New Jellyfin version ! Still a few TODOs. See next comment.

Many [new features](https://jellyfin.org/posts/jellyfin-release-10.9.0/). Also fixes automatic server discovery (#141).

Some warnings i don't know what to do about:

```
Attention : File /etc/jellyfin/network.xml has been manually modified since the installation or last upgrade. So it has been duplicated in /var/cache/yunohost/appconfbackup//etc/jellyfin/network.xml.backup.20240512.205528
Attention : --- /var/cache/yunohost/appconfbackup//etc/jellyfin/network.xml.backup.20240512.205528      2024-05-12 20:55:00.687566755 +0200
Attention : +++ /etc/jellyfin/network.xml       2024-05-12 20:55:28.335544109 +0200
Attention : @@ -2,35 +2,14 @@
Attention :  <NetworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
Attention :    <RequireHttps>false</RequireHttps>
Attention :    <BaseUrl>/media</BaseUrl>
Attention : -  <PublicHttpsPort>8920</PublicHttpsPort>
Attention : -  <HttpServerPortNumber>8095</HttpServerPortNumber>
Attention : -  <HttpsPortNumber>8920</HttpsPortNumber>
Attention : +  <InternalHttpPort>8095</InternalHttpPort>
Attention :    <EnableHttps>false</EnableHttps>
Attention : -  <PublicPort>8095</PublicPort>
Attention : -  <UPnPCreateHttpPortMap>false</UPnPCreateHttpPortMap>
Attention : -  <UDPPortRange />
Attention :    <EnableIPV6>true</EnableIPV6>
Attention :    <EnableIPV4>true</EnableIPV4>
Attention : -  <EnableSSDPTracing>false</EnableSSDPTracing>
Attention : -  <SSDPTracingFilter />
Attention : -  <UDPSendCount>2</UDPSendCount>
Attention : -  <UDPSendDelay>100</UDPSendDelay>
Attention : -  <IgnoreVirtualInterfaces>true</IgnoreVirtualInterfaces>
Attention : -  <VirtualInterfaceNames>vEthernet*</VirtualInterfaceNames>
Attention : -  <GatewayMonitorPeriod>60</GatewayMonitorPeriod>
Attention : -  <TrustAllIP6Interfaces>false</TrustAllIP6Interfaces>
Attention : -  <HDHomerunPortRange />
Attention : -  <PublishedServerUriBySubnet>
Attention : -    <string>https://kl.netlib.re/media</string>
Attention : -  </PublishedServerUriBySubnet>
Attention : -  <AutoDiscoveryTracing>false</AutoDiscoveryTracing>
Attention :    <AutoDiscovery>true</AutoDiscovery>
Attention : -  <RemoteIPFilter />
Attention : -  <IsRemoteIPFilterBlacklist>false</IsRemoteIPFilterBlacklist>
Attention :    <EnableUPnP>true</EnableUPnP>
Attention :    <EnableRemoteAccess>true</EnableRemoteAccess>
Attention : -  <LocalNetworkSubnets />
Attention : -  <LocalNetworkAddresses />
Attention : -  <KnownProxies />
Attention : -  <EnablePublishedServerUriByRequest>false</EnablePublishedServerUriByRequest>
Attention : -</NetworkConfiguration>
Attention : \ Pas de fin de ligne à la fin du fichier
Attention : +  <LocalNetworkAddresses>
Attention : +    <string>127.0.0.1</string>
Attention : +  </LocalNetworkAddresses>
Attention : +</NetworkConfiguration>
```

Some warnings i added to move old plugins directory instead of accumulating dust:

```
Attention : Jellyfin plugin 'LDAP Authentication' has different ABI version 10.8.0.0 than expected 10.9.0.0. Moving to /var/lib/jellyfin/plugins-backup.
Attention : Jellyfin plugin 'LDAP Authentication_12.0.0.0' has different ABI version 10.7.0.0 than expected 10.9.0.0. Moving to /var/lib/jellyfin/plugins-backup.
Attention : Jellyfin plugin 'Open Subtitles_10.0.0.0' has different ABI version 10.7.0.0 than expected 10.9.0.0. Moving to /var/lib/jellyfin/plugins-backup.
Attention : Jellyfin plugin 'Open Subtitles_11.0.0.0' has different ABI version 10.7.0.0 than expected 10.9.0.0. Moving to /var/lib/jellyfin/plugins-backup.
Attention : Jellyfin plugin 'Open Subtitles_19.0.0.0' has different ABI version 10.8.10.0 than expected 10.9.0.0. Moving to /var/lib/jellyfin/plugins-backup.
```