### PR TITLE
Update URLs to point to new file locations.

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -58,13 +58,13 @@ ram.runtime = "100M"
 [resources]
     [resources.sources]
     [resources.sources.server]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_armhf.deb"
+    armhf.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_armhf.deb"
     armhf.sha256 = "ee4588aeeb55282b044d3bb4efef146a43abd742d3ef9327e042b2959008dc60"
 
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_arm64.deb"
+    arm64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_arm64.deb"
     arm64.sha256 = "b9b917ec6ed4ddd3c728cb7be84245ff625c0a7ae12653a921cb3a9f6149252d"
 
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_amd64.deb"
+    amd64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/stable/server/10.8.13/jellyfin-server_10.8.13-1_amd64.deb"
     amd64.sha256 = "d54decc098d5e61be50847edba8722d6468e22134bae2df514859e064eb8d727"
 
     rename = "jellyfin-server.deb"
@@ -72,7 +72,7 @@ ram.runtime = "100M"
     extract = false
 
     [resources.sources.web]
-    url = "https://repo.jellyfin.org/releases/server/debian/versions/stable/web/10.8.13/jellyfin-web_10.8.13-1_all.deb"
+    url = "https://repo.jellyfin.org/files/releases/server/debian/versions/stable/web/10.8.13/jellyfin-web_10.8.13-1_all.deb"
     sha256 = "8a30e2239f97d1d749f6059db0ff1e4189f44babfb9b0cf236102b7c95b0babe"
 
     rename = "jellyfin-web.deb"
@@ -81,13 +81,13 @@ ram.runtime = "100M"
 
 
     [resources.sources.ffmpeg_bookworm]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_armhf.deb"
+    armhf.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_armhf.deb"
     armhf.sha256 = "bdb28e67fa4dc8e321366c4a19e18bcc6166a60d6aa5a4bf2da1263489b4f25f"
 
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_arm64.deb"
+    arm64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_arm64.deb"
     arm64.sha256 = "aabf62104399f242ddb7b8c2e308976f6b233ceac5ffccbabd340a28e428ca3c"
 
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_amd64.deb"
+    amd64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bookworm_amd64.deb"
     amd64.sha256 = "cb40c04e026d83b9265535e214f883d4a26824b5703304064fd38fffa70ac449"
 
     rename = "jellyfin-ffmpeg6.deb"
@@ -96,13 +96,13 @@ ram.runtime = "100M"
 
 
     [resources.sources.ffmpeg_bullseye]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_armhf.deb"
+    armhf.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_armhf.deb"
     armhf.sha256 = "700bab9e8c96594f83d731019cdbc20fbab303c1d8440288e463e372cd16ed7a"
 
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_arm64.deb"
+    arm64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_arm64.deb"
     arm64.sha256 = "56ef93f285e922417cda98b109021be614a5307d9d7c18aff22fa0c439ab77b5"
 
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_amd64.deb"
+    amd64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-bullseye_amd64.deb"
     amd64.sha256 = "50b0cbd2cd0ab64fd6803d2bdfd15946ec6f80c0b492f81ad85e921ffafdcf7e"
 
     rename = "jellyfin-ffmpeg6.deb"
@@ -111,13 +111,13 @@ ram.runtime = "100M"
 
 
     [resources.sources.ffmpeg_buster]
-    armhf.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_armhf.deb"
+    armhf.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_armhf.deb"
     armhf.sha256 = "6f3beae72aec030aae96dc044bfcf736f12fc135cc574cde8085609e47374a43"
 
-    arm64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_arm64.deb"
+    arm64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_arm64.deb"
     arm64.sha256 = "109ea41f17e314e3e9b32689844841ddd54a600419ff89e0e979e195a25b91c5"
 
-    amd64.url = "https://repo.jellyfin.org/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_amd64.deb"
+    amd64.url = "https://repo.jellyfin.org/files/releases/server/debian/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-buster_amd64.deb"
     amd64.sha256 = "a1c55b7f439f2b9a487ea90341a280467f1973fcd12607f08bcd16cf22ce307a"
     
     rename = "jellyfin-ffmpeg6.deb"
@@ -126,7 +126,7 @@ ram.runtime = "100M"
 
 
     [resources.sources.plugin_ldap]
-    url = "https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_17.0.0.0.zip"
+    url = "https://repo.jellyfin.org/files/releases/plugin/ldap-authentication/ldap-authentication_17.0.0.0.zip"
     sha256 = "042bdd16950c7569c154311cc64af49c7d6096e9b0a7184287707d5ee317ecf5"
     in_subdir = false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+tomlkit


### PR DESCRIPTION
Add requirements.txt.
Compute sha256 checksum for ldap plugin zip

## Problem

- The package repository url changed
- I think the #146 has the same issue 

## Solution

- Update the links to point the proper repo url

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
