### PR TITLE
Remove header for LG TV apps

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -11,6 +11,12 @@ location __PATH__/ {
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection $http_connection;
 
+  # Disable a specific header for compatability with LG TV app
+  # Fixes https://github.com/YunoHost-Apps/jellyfin_ynh/issues/125
+  if ($http_user_agent ~ Web0S) {
+    more_set_headers X-Frame-Options : "";
+  }
+
   # Disable buffering when the nginx proxy gets very resource heavy upon streaming
   proxy_buffering off;
 


### PR DESCRIPTION
## Problem

Fixes #125

## Solution

- Updated nginx config to exclude the `X-Frame-Options` header when responding to clients sending `WebOS` in their user agent.
- I have manually tested and confirmed the fix with my own TV.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
