### PR TITLE
enh(doc): mention multimedia directories right after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,17 @@ Media System that manage and stream your media
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://jellyfin.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://demo.jellyfin.org/stable/web/index.html)
-[![Version: 10.10.7~ynh1](https://img.shields.io/badge/Version-10.10.7~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
+[![Version: 10.10.7~ynh1](https://img.shields.io/badge/Version-10.10.7~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/jellyfin"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>
 <a href="https://github.com/YunoHost-Apps/jellyfin_ynh/issues"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_report_an_issue.svg"/></a>
 </div>
+
+
+## Screenshots
+![Screenshot of Jellyfin](./doc/screenshots/jellyfin-1.jpg)
+![Screenshot of Jellyfin](./doc/screenshots/jellyfin-2.jpg)
 
 ## 📦 Developer info
 

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,10 +1,18 @@
-* The app relies on YunoHost's LDAP server for users to log in:
+# Connection
+
+The app relies on YunoHost's LDAP server for users to log in:
   * Standard users need the `main` permission;
   * Users with the `admin` permission will have access to the administration panel.
 
-* The app can access YunoHost's multimedia directories:
-  
-  Choose one of the folders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
+# Multimedia folders
 
-* __APP__ has its discovery ports (1900 and 7359) closed by default. These are used to offer automatic discovery of your Jellyfin instance to any compatible client connected on the same network (your local network).
+The app can access YunoHost's multimedia directories:
+
+Choose one of the subfolders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
+
+These directories are shared with other applications to facilitate files upload and management.
+
+# Opening ports for local usage
+
+__APP__ has its discovery ports (1900 and 7359) closed by default. These are used to offer automatic discovery of your Jellyfin instance to any compatible client connected on the same network (your local network).
 To take advantage of this feature, you *can* open ports 1900 and 7359 **UDP** if your server is hosted at home, on your local network (in other words, not a VPS).

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -6,11 +6,9 @@ The app relies on YunoHost's LDAP server for users to log in:
 
 # Multimedia folders
 
-The app can access YunoHost's multimedia directories:
+The app can access YunoHost's multimedia directories. These directories are shared with other applications to facilitate files upload and management.
 
 If you want to use them, choose one of the subfolders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
-
-These directories are shared with other applications to facilitate files upload and management.
 
 # Opening ports for local usage
 

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -8,7 +8,7 @@ The app relies on YunoHost's LDAP server for users to log in:
 
 The app can access YunoHost's multimedia directories:
 
-Choose one of the subfolders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
+If you want to use them, choose one of the subfolders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
 
 These directories are shared with other applications to facilitate files upload and management.
 

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -6,10 +6,10 @@ L'app repose sur le serveur LDAP de YunoHost pour gérer les connexions:
 
 # Dossiers multimédias
 
-L'app a accès aux dossiers multimédia de YunoHost:
-indiquez un des sous-dossiers de `/home/yunohost.multimedia/share` comme source lors du paramétrage de vos bibliothèques.
+L'app a accès aux dossiers multimédia de YunoHost. Ces dossiers sont partagés avec d'autres applications pour faciliter l'ajout de fichiers et leur gestion.
 
-Ces dossiers sont partagés avec d'autres applications pour faciliter l'ajout de fichiers et leur gestion.
+Si vous souhaitez les utiliser, indiquez un des sous-dossiers de `/home/yunohost.multimedia/share` comme source lors du paramétrage de vos bibliothèques.
+
 
 # Ouverture des ports pour une utilisation locale
 

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,9 +1,18 @@
-* L'app repose sur le serveur LDAP de YunoHost pour gérer les connexions:
+# Connexion
+
+L'app repose sur le serveur LDAP de YunoHost pour gérer les connexions:
   * Les utilisateurs standards doivent avoir la permission `main` ;
   * Les utilisateurs doivent avoir la permission `admin` pour pouvoir accéder au panneau d'administration.
 
-* L'app a accès aux dossiers multimédia de YunoHost:
-indiquez un des dossiers de `/home/yunohost.multimedia/share` comme source lors du paramétrage de vos bibliothèques.
+# Dossiers multimédias
 
-* __APP__ a ses ports de découverte (1900 et 7359) fermés par défaut. Ceux-ci servent à proposer la découverte automatique de votre instance Jellyfin à tout client compatible connectés sur le même réseau (votre réseau local).
+L'app a accès aux dossiers multimédia de YunoHost:
+indiquez un des sous-dossiers de `/home/yunohost.multimedia/share` comme source lors du paramétrage de vos bibliothèques.
+
+Ces dossiers sont partagés avec d'autres applications pour faciliter l'ajout de fichiers et leur gestion.
+
+# Ouverture des ports pour une utilisation locale
+
+__APP__ a ses ports de découverte (1900 et 7359) fermés par défaut. Ceux-ci servent à proposer la découverte automatique de votre instance Jellyfin à tout client compatible connecté sur le même réseau (votre réseau local).
+
 Pour pouvoir bénéficier de cette fonctionnalité, vous *pouvez* ouvrir les ports 1900 et 7359 **UDP** si vous êtes sur votre serveur est hébergé chez vous, sur votre réseau local (autrement dit, pas un VPS).

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -3,11 +3,10 @@ Congratulations! The installation was a success! 🎉
 
 # Multimedia folders
 
-The app can access YunoHost's multimedia directories:
+The app can access YunoHost's multimedia directories. These directories are shared with other applications to facilitate files upload and management.
 
-Choose one of the subfolders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
+I fou want to use them, choose one of the subfolders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
 
-These directories are shared with other applications to facilitate files upload and management.
 
 # Opening ports for local usage
 

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,7 +1,15 @@
 
 Congratulations! The installation was a success! 🎉
 
+# Multimedia folders
+
+The app can access YunoHost's multimedia directories:
+
+Choose one of the subfolders in `/home/yunohost.multimedia/share` upon configuration of your libraries.
+
+These directories are shared with other applications to facilitate files upload and management.
+
+# Opening ports for local usage
+
 __APP__ has its discovery ports (1900 and 7359) closed by default. These are used to offer automatic discovery of your Jellyfin instance to any compatible client connected on the same network (your local network).
-
-
 To take advantage of this feature, you *can* open ports 1900 and 7359 **UDP** if your server is hosted at home, on your local network (in other words, not a VPS).

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -1,6 +1,15 @@
 
 Félicitations ! L’installation a réussi ! 🎉
 
+# Dossiers multimédias
+
+L'app a accès aux dossiers multimédia de YunoHost:
+indiquez un des sous-dossiers de `/home/yunohost.multimedia/share` comme source lors du paramétrage de vos bibliothèques.
+
+Ces dossiers sont partagés avec d'autres applications pour faciliter l'ajout de fichiers et leur gestion.
+
+# Ouverture des ports pour une utilisation locale
+
 __APP__ a ses ports de découverte (1900 et 7359) fermés par défaut. Ceux-ci servent à proposer la découverte automatique de votre instance Jellyfin à tout client compatible connecté sur le même réseau (votre réseau local).
 
 Pour pouvoir bénéficier de cette fonctionnalité, vous *pouvez* ouvrir les ports 1900 et 7359 **UDP** si vous êtes sur votre serveur est hébergé chez vous, sur votre réseau local (autrement dit, pas un VPS).

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -3,10 +3,10 @@ Félicitations ! L’installation a réussi ! 🎉
 
 # Dossiers multimédias
 
-L'app a accès aux dossiers multimédia de YunoHost:
-indiquez un des sous-dossiers de `/home/yunohost.multimedia/share` comme source lors du paramétrage de vos bibliothèques.
+L'app a accès aux dossiers multimédia de YunoHost. Ces dossiers sont partagés avec d'autres applications pour faciliter l'ajout de fichiers et leur gestion.
 
-Ces dossiers sont partagés avec d'autres applications pour faciliter l'ajout de fichiers et leur gestion.
+Si vous souhaitez les utiliser, indiquez un des sous-dossiers de `/home/yunohost.multimedia/share` comme source lors du paramétrage de vos bibliothèques.
+
 
 # Ouverture des ports pour une utilisation locale
 


### PR DESCRIPTION
Lower risk of user confusion: https://forum.yunohost.org/t/where-to-put-jellyfin-media-files/40095
 
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
