### PR TITLE
document configs that break Swiftfin

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -8,3 +8,5 @@
 
 * __APP__ has its discovery ports (1900 and 7359) closed by default. These are used to offer automatic discovery of your Jellyfin instance to any compatible client connected on the same network (your local network).
 To take advantage of this feature, you *can* open ports 1900 and 7359 **UDP** if your server is hosted at home, on your local network (in other words, not a VPS).
+
+*Some clients (notably the Swiftfin client for iOS and tvOS devices) will fail to play media if TLSv1.2 isn't enabled. To ensure TLSv1.2 is enabled, make sure the NGINX Compatibility setting in the web admin UI (under Yunohost Settings > Security > NGINX) is set to "Intermediate" and not "Modern".


### PR DESCRIPTION
## Problem

Certain configs for the Yunohost global settings break the Swiftfin iOS/tvOS Jellyfin client.

## Solution

Documented the config settings that break the client in ADMIN.md

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
