### PR TITLE
Use tar archives instead of debs and use standard YunoHost directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Media System that manage and stream your media
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://jellyfin.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://demo.jellyfin.org/stable/web/index.html)
-[![Version: 10.11.6~ynh1](https://img.shields.io/badge/Version-10.11.6~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
+[![Version: 10.11.6~ynh2](https://img.shields.io/badge/Version-10.11.6~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/jellyfin"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Media System that manage and stream your media
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://jellyfin.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://demo.jellyfin.org/stable/web/index.html)
-[![Version: 10.11.6~ynh2](https://img.shields.io/badge/Version-10.11.6~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
+[![Version: 10.11.7~ynh1](https://img.shields.io/badge/Version-10.11.7~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/jellyfin"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/.env
+++ b/conf/.env
@@ -1,0 +1,31 @@
+JELLYFINDIR=__INSTALL_DIR__/jellyfin
+FFMPEGDIR=__INSTALL_DIR__/ffmpeg
+
+# Program directories
+JELLYFIN_DATA_DIR=__DATA_DIR__
+JELLYFIN_CONFIG_DIR=__INSTALL_DIR__/config
+JELLYFIN_CACHE_DIR=__INSTALL_DIR__/cache
+JELLYFIN_LOG_DIR=/var/log/__APP__
+
+JELLYFIN_PublishedServerUrl=https://__DOMAIN____PATH__
+
+# web client path, installed by the jellyfin-web package
+JELLYFIN_WEB_OPT="--webdir=__INSTALL_DIR__/jellyfin/jellyfin-web"
+
+# ffmpeg binary paths, overriding the system values
+JELLYFIN_FFMPEG_OPT="--ffmpeg=__INSTALL_DIR__/ffmpeg/ffmpeg"
+
+# Disable glibc dynamic heap adjustment
+#MALLOC_TRIM_THRESHOLD_=131072
+
+# [OPTIONAL] run Jellyfin as a headless service
+JELLYFIN_SERVICE_OPT="--service"
+
+# [OPTIONAL] run Jellyfin without the web app
+#JELLYFIN_NOWEBAPP_OPT="--nowebclient"
+
+# Space to add additional command line options to jellyfin (for help see ~$ jellyfin --help)
+#JELLYFIN_ADDITIONAL_OPTS=""
+
+# Application username
+JELLYFIN_USER="__APP__"

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,7 +16,7 @@ location __PATH__/ {
   proxy_buffering off;
 }
 location __PATH__/socket {
-  proxy_pass http://127.0.0.1:__PORT____PATH___/socket;
+  proxy_pass http://127.0.0.1:__PORT____PATH__/socket;
   include proxy_params_with_auth;
   proxy_set_header X-Forwarded-Protocol $scheme;
 }

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,2 +1,50 @@
+[Unit]
+Description=Jellyfin
+After=network.target
+
 [Service]
-Environment="JELLYFIN_PublishedServerUrl=https://__DOMAIN____PATH__"
+Type=simple
+User=__APP__
+Group=__APP__
+WorkingDirectory=__INSTALL_DIR__/jellyfin
+EnvironmentFile=__INSTALL_DIR__/.env
+ExecStart=__INSTALL_DIR__/jellyfin/jellyfin -d __DATA_DIR__ -c __INSTALL_DIR__/config --ffmpeg __INSTALL_DIR__/ffmpeg/ffmpeg
+StandardOutput=append:/var/log/__APP__/__APP__.log
+StandardError=inherit
+
+### Depending on specificities of your service/app, you may need to tweak these
+### .. but this should be a good baseline
+# Sandboxing options to harden security
+# Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+DevicePolicy=closed
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+ProtectSystem=full
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap @cpu-emulation @privileged
+
+# Denying access to capabilities that should not be relevant for webapps
+# Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html
+CapabilityBoundingSet=~CAP_RAWIO CAP_MKNOD
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_SYS_BOOT CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_LEASE CAP_LINUX_IMMUTABLE CAP_IPC_LOCK
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
+CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG
+
+[Install]
+WantedBy=multi-user.target

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin"
 description.en = "Media System that manage and stream your media"
 description.fr = "Système multimédia qui gère et diffuse vos médias"
 
-version = "10.11.6~ynh1"
+version = "10.11.6~ynh2"
 
 maintainers = ["tituspijean"]
 
@@ -24,9 +24,10 @@ fund = "https://opencollective.com/jellyfin"
 yunohost = ">= 12.1.39"
 helpers_version = "2.1"
 architectures = ["arm64", "amd64"]
-multi_instance = false
+multi_instance = true
 
 ldap = true
+
 sso = true
 
 disk = "300M"
@@ -56,106 +57,37 @@ ram.runtime = "100M"
 
 [resources]
 
-    [resources.sources.server_bookworm]
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/arm64/jellyfin-server_10.11.6+deb12_arm64.deb"
-    arm64.sha256 = "af9ded4622f228436f2ab28b0dc05b0b15f30fe13098844e93ed489d5a524cc4"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-server_10.11.6+deb12_amd64.deb"
-    amd64.sha256 = "bdf37bb8118ad37c0d7b2609c7697c1a10dd0c7267444c1fd81c3dc138a4d360"
+    [resources.sources.main]
+    arm64.url = "https://repo.jellyfin.org/files/server/linux/stable/v10.11.6/arm64/jellyfin_10.11.6-arm64.tar.xz"
+    arm64.sha256 = "811a69a3494877e10f6ddd431375ca754ae49758fcf7da30f2289db484183e28"
+    amd64.url = "https://repo.jellyfin.org/files/server/linux/stable/v10.11.6/amd64/jellyfin_10.11.6-amd64.tar.xz"
+    amd64.sha256 = "f281ded1c01211799559c6f70d6ea35031cc9ff2d3756a4c1573bcf2ff3c2695"
 
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-server.deb"
+    format = "tar.xz"
+    extract = true
+    in_subdir = true
     prefetch = false
 
-    [resources.sources.server_archive_bookworm]
-    arm64.url = "https://repo.jellyfin.org/archive/server/debian/stable/v10.11.6/arm64/jellyfin-server_10.11.6+deb12_arm64.deb"
-    arm64.sha256 = "af9ded4622f228436f2ab28b0dc05b0b15f30fe13098844e93ed489d5a524cc4"
-    amd64.url = "https://repo.jellyfin.org/archive/server/debian/stable/v10.11.6/amd64/jellyfin-server_10.11.6+deb12_amd64.deb"
-    amd64.sha256 = "bdf37bb8118ad37c0d7b2609c7697c1a10dd0c7267444c1fd81c3dc138a4d360"
+    [resources.sources.main_archive]
+    arm64.url = "https://repo.jellyfin.org/archive/server/linux/stable/v10.11.6/arm64/jellyfin_10.11.6-arm64.tar.xz"
+    arm64.sha256 = "811a69a3494877e10f6ddd431375ca754ae49758fcf7da30f2289db484183e28"
+    amd64.url = "https://repo.jellyfin.org/archive/server/linux/stable/v10.11.6/amd64/jellyfin_10.11.6-amd64.tar.xz"
+    amd64.sha256 = "f281ded1c01211799559c6f70d6ea35031cc9ff2d3756a4c1573bcf2ff3c2695"
 
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-server.deb"
+    format = "tar.xz"
+    extract = true
+    in_subdir = true
     prefetch = false
 
-    [resources.sources.server_trixie]
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/arm64/jellyfin-server_10.11.6+deb13_arm64.deb"
-    arm64.sha256 = "7ddbb98426a3c752a9cb0c8b3b959ab070d20a75c49067360b3ea9187c5a8c3f"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-server_10.11.6+deb13_amd64.deb"
-    amd64.sha256 = "5d84f65a61185bf65da3f2bef56070a4609fbc9470794375b9bd6c5de749a5cb"
+    [resources.sources.ffmpeg]
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/linux/7.x/7.1.3-1/arm64/jellyfin-ffmpeg_7.1.3-1_portable_linuxarm64-gpl.tar.xz"
+    arm64.sha256 = "d0f2b240015d92b3e44d8b0f2d2f43a7fbfa880c9afb54c45a1a457d81ada611"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/linux/7.x/7.1.3-1/amd64/jellyfin-ffmpeg_7.1.3-1_portable_linux64-gpl.tar.xz"
+    amd64.sha256 = "8d6bfac414d3be6e14e832e97e14da99a7258c482bfd1a869002e10133ebda1f"
 
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-server.deb"
-    prefetch = false
-
-    [resources.sources.server_archive_trixie]
-    arm64.url = "https://repo.jellyfin.org/archive/server/debian/stable/v10.11.6/arm64/jellyfin-server_10.11.6+deb13_arm64.deb"
-    arm64.sha256 = "7ddbb98426a3c752a9cb0c8b3b959ab070d20a75c49067360b3ea9187c5a8c3f"
-    amd64.url = "https://repo.jellyfin.org/archive/server/debian/stable/v10.11.6/amd64/jellyfin-server_10.11.6+deb13_amd64.deb"
-    amd64.sha256 = "5d84f65a61185bf65da3f2bef56070a4609fbc9470794375b9bd6c5de749a5cb"
-
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-server.deb"
-    prefetch = false
-
-    [resources.sources.web_bookworm]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-web_10.11.6+deb12_all.deb"
-    sha256 = "d0d917002423209e529140200ef6eefffe1d22f749a17433c13cea01f248d212"
-
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-web.deb"
-    prefetch = false
-
-    [resources.sources.web_archive_bookworm]
-    url = "https://repo.jellyfin.org/archive/server/debian/stable/v10.11.6/amd64/jellyfin-web_10.11.6+deb12_all.deb"
-    sha256 = "d0d917002423209e529140200ef6eefffe1d22f749a17433c13cea01f248d212"
-
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-web.deb"
-    prefetch = false
-
-    [resources.sources.web_trixie]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-web_10.11.6+deb13_all.deb"
-    sha256 = "945365c42db30dc620aa977b484d6cda404367cd0b6888549d2a6513825d949b"
-
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-web.deb"
-    prefetch = false
-
-    [resources.sources.web_archive_trixie]
-    url = "https://repo.jellyfin.org/archive/server/debian/stable/v10.11.6/amd64/jellyfin-web_10.11.6+deb13_all.deb"
-    sha256 = "945365c42db30dc620aa977b484d6cda404367cd0b6888549d2a6513825d949b"
-
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-web.deb"
-    prefetch = false
-
-    [resources.sources.ffmpeg_bookworm]
-    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/arm64/jellyfin-ffmpeg7_7.1.3-1-bookworm_arm64.deb"
-    arm64.sha256 = "c1f069bae4f72ea401a2005847ebd019fd91738d2a443563a8d992ce29a18ee8"
-    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/amd64/jellyfin-ffmpeg7_7.1.3-1-bookworm_amd64.deb"
-    amd64.sha256 = "ee2fd205c86c630ed15c91c534adc33df7ce09a35bef5f42fd1ee119d26728ee"
-
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-ffmpeg7.deb"
-
-    [resources.sources.ffmpeg_trixie]
-    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/arm64/jellyfin-ffmpeg7_7.1.3-1-trixie_arm64.deb"
-    arm64.sha256 = "ff8a8b5aa622272c044495c95a01f97858f09df743f667d4640b3882bb795f8c"
-    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/amd64/jellyfin-ffmpeg7_7.1.3-1-trixie_amd64.deb"
-    amd64.sha256 = "5b97d8aa2b7a219df3723c5dda481a3cda42b892ca0e6385f899e25a7448255b"
-
-    format = "whatever"
-    extract = false
-    rename = "jellyfin-ffmpeg7.deb"
-
+    format = "tar.xz"
+    extract = true
+    in_subdir = false
 
     [resources.sources.plugin_ldap]
     url = "https://repo.jellyfin.org/files/plugin/ldap-authentication/ldap-authentication_22.0.0.0.zip"
@@ -163,10 +95,10 @@ ram.runtime = "100M"
     in_subdir = false
 
     [resources.system_user]
-    home = "/var/lib/jellyfin"
 
     [resources.install_dir]
-    dir = "/var/lib/jellyfin"
+
+    [resources.data_dir]
 
     [resources.permissions]
     # auth_header=false is because Jellyfin expects custom data in the Authorization HTTP header (notably, for Jellyfin Vue)

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin"
 description.en = "Media System that manage and stream your media"
 description.fr = "Système multimédia qui gère et diffuse vos médias"
 
-version = "10.11.6~ynh2"
+version = "10.11.7~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -58,10 +58,10 @@ ram.runtime = "100M"
 [resources]
 
     [resources.sources.main]
-    arm64.url = "https://repo.jellyfin.org/files/server/linux/stable/v10.11.6/arm64/jellyfin_10.11.6-arm64.tar.xz"
-    arm64.sha256 = "811a69a3494877e10f6ddd431375ca754ae49758fcf7da30f2289db484183e28"
-    amd64.url = "https://repo.jellyfin.org/files/server/linux/stable/v10.11.6/amd64/jellyfin_10.11.6-amd64.tar.xz"
-    amd64.sha256 = "f281ded1c01211799559c6f70d6ea35031cc9ff2d3756a4c1573bcf2ff3c2695"
+    arm64.url = "https://repo.jellyfin.org/files/server/linux/stable/v10.11.7/arm64/jellyfin_10.11.7-arm64.tar.xz"
+    arm64.sha256 = "c73dfc8d1ae13433715a81a4bbcb7f06eb512a71f2b0d3e354dd6516388b18e5"
+    amd64.url = "https://repo.jellyfin.org/files/server/linux/stable/v10.11.7/amd64/jellyfin_10.11.7-amd64.tar.xz"
+    amd64.sha256 = "c5631a8e492a300dc47700725690c004bf390055c2e16cce236eae0101020fcc"
 
     format = "tar.xz"
     extract = true
@@ -69,10 +69,10 @@ ram.runtime = "100M"
     prefetch = false
 
     [resources.sources.main_archive]
-    arm64.url = "https://repo.jellyfin.org/archive/server/linux/stable/v10.11.6/arm64/jellyfin_10.11.6-arm64.tar.xz"
-    arm64.sha256 = "811a69a3494877e10f6ddd431375ca754ae49758fcf7da30f2289db484183e28"
-    amd64.url = "https://repo.jellyfin.org/archive/server/linux/stable/v10.11.6/amd64/jellyfin_10.11.6-amd64.tar.xz"
-    amd64.sha256 = "f281ded1c01211799559c6f70d6ea35031cc9ff2d3756a4c1573bcf2ff3c2695"
+    arm64.url = "https://repo.jellyfin.org/archive/server/linux/stable/v10.11.7/arm64/jellyfin_10.11.7-arm64.tar.xz"
+    arm64.sha256 = "c73dfc8d1ae13433715a81a4bbcb7f06eb512a71f2b0d3e354dd6516388b18e5"
+    amd64.url = "https://repo.jellyfin.org/archive/server/linux/stable/v10.11.7/amd64/jellyfin_10.11.7-amd64.tar.xz"
+    amd64.sha256 = "c5631a8e492a300dc47700725690c004bf390055c2e16cce236eae0101020fcc"
 
     format = "tar.xz"
     extract = true
@@ -80,10 +80,10 @@ ram.runtime = "100M"
     prefetch = false
 
     [resources.sources.ffmpeg]
-    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/linux/7.x/7.1.3-1/arm64/jellyfin-ffmpeg_7.1.3-1_portable_linuxarm64-gpl.tar.xz"
-    arm64.sha256 = "d0f2b240015d92b3e44d8b0f2d2f43a7fbfa880c9afb54c45a1a457d81ada611"
-    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/linux/7.x/7.1.3-1/amd64/jellyfin-ffmpeg_7.1.3-1_portable_linux64-gpl.tar.xz"
-    amd64.sha256 = "8d6bfac414d3be6e14e832e97e14da99a7258c482bfd1a869002e10133ebda1f"
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/linux/7.x/7.1.3-4/arm64/jellyfin-ffmpeg_7.1.3-4_portable_linuxarm64-gpl.tar.xz"
+    arm64.sha256 = "5efb50df7a817015340b01111d2c2c8f24d82a060bd88f7ad49bcbdecf0fefbe"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/linux/7.x/7.1.3-4/amd64/jellyfin-ffmpeg_7.1.3-4_portable_linux64-gpl.tar.xz"
+    amd64.sha256 = "fa77f7e7cadf4539db7f7ef9b18e96070198d377e4aa76f6154be50e0df7da5d"
 
     format = "tar.xz"
     extract = true

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -16,65 +16,31 @@ ffmpeg_pkg_version="7.1.3-1"
 plugin_abi="10.11.0"
 ldap_pkg_version="22.0.0.0"
 
-# Those directories are handled by the deb package
-data_path="/var/lib/$app"
-config_path="/etc/$app"
+config_path="$install_dir/config"
 log_path="/var/log/$app"
-cache_path="/var/cache/$app"
+cache_path="$install_dir/cache"
 
 install_jellyfin_packages() {
-	# Get version numbers from manifest UNUSED because update_version.py uses the hard-coded variables
-	# pkg_version="$(ynh_app_upstream_version)"
-	# ffmpeg_url="$(ynh_read_manifest "resources.sources.ffmpeg_${debian}.${YNH_ARCH}.url")"
-	# ffmpeg_pkg_version="$(echo "$ffmpeg_url" | sed "s/.*\/jellyfin-ffmpeg[0-9]*_\([0-9.-]*\)-${debian}_${YNH_ARCH}.deb/\1/")"
+    # If there is a new version, the server resource is moved to archive
+    main_url="$(ynh_read_manifest "resources.sources.main.${YNH_ARCH}.url")"
+    main_resource="main"
+    if ! curl --output /dev/null --silent --head --fail "$main_url"; then
+    	main_resource="main_archive"
+    fi
 
-	# We need to workaround yunohost passing --no-remove to replace jellyfin-ffmpeg5 and 6...
-	for ffmpeg_installed_version in "jellyfin-ffmpeg5" "jellyfin-ffmpeg6"
-	do
-		if _ynh_apt_package_is_installed "$ffmpeg_installed_version"; then
-			ynh_apt_remove_dependencies "$ffmpeg_installed_version"
-		fi
-	done
-
-	# This should only run on upgrade, to fix https://github.com/YunoHost-Apps/jellyfin_ynh/issues/163
-	# Previously the package depended on exact package versions, so upgrade was broken.
-	if _ynh_apt_package_is_installed "$app-ynh-deps" && _ynh_apt_package_is_installed "jellyfin-server"; then
-		ynh_apt_install_dependencies jellyfin-web jellyfin-ffmpeg7 jellyfin-server
-	fi
-
-	# Create the temporary directory
-	tempdir="$(mktemp -d)"
-
-	# If there is a new version, the web and server resources are moved to archive
-	server_url="$(ynh_read_manifest "resources.sources.server_${debian}.${YNH_ARCH}.url")"
-	server_resource="server_$debian"
-	if ! curl --output /dev/null --silent --head --fail "$server_url"; then
-		server_resource="server_archive_$debian"
-	fi
-	web_url="$(ynh_read_manifest "resources.sources.web_${debian}.url")"
-	web_resource="web_$debian"
-	if ! curl --output /dev/null --silent --head --fail "$web_url"; then
-		web_resource="web_archive_$debian"
-	fi
-	# Download the deb files
-	ynh_setup_source --dest_dir="$tempdir" --source_id="$web_resource"
-	ynh_setup_source --dest_dir="$tempdir" --source_id="ffmpeg_$debian"
-	ynh_setup_source --dest_dir="$tempdir" --source_id="$server_resource"
-
-	# Install the packages. Allow downgrades because apt decided bullseye > bookworm
-	_ynh_apt_install --allow-downgrades \
-		"$tempdir/jellyfin-web.deb" \
-		"$tempdir/jellyfin-server.deb"
-
-	# Install the packages. Allow downgrades because apt decided bullseye > bookworm
-	_ynh_apt_install --allow-downgrades \
-		"${tempdir}/jellyfin-ffmpeg7.deb"
-
-	# The doc says it should be called only once,
-	# but the code says multiple calls are supported.
-	# Also, they're already installed so that should be quasi instantaneous.
-	ynh_apt_install_dependencies jellyfin-web jellyfin-ffmpeg7 jellyfin-server
-
-	# Mark packages as dependencies, to allow automatic removal
-	apt-mark auto jellyfin-server jellyfin-web jellyfin-ffmpeg7
+    ynh_setup_source --dest_dir="$install_dir/jellyfin" --source_id="$main_resource"
+    ynh_setup_source --dest_dir="$install_dir/ffmpeg" --source_id="ffmpeg"
 }
+
+upgrade_jellyfin_packages() {
+    # If there is a new version, the server resource is moved to archive
+    main_url="$(ynh_read_manifest "resources.sources.main.${YNH_ARCH}.url")"
+    main_resource="main"
+    if ! curl --output /dev/null --silent --head --fail "$main_url"; then
+    	main_resource="main_archive"
+    fi
+
+    ynh_setup_source --dest_dir="$install_dir/jellyfin/" --source_id="$main_resource" --full_replace --keep="config"
+    ynh_setup_source --dest_dir="$install_dir/ffmpeg" --source_id="ffmpeg"
+}
+

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,10 +6,10 @@
 
 debian=$(lsb_release --codename --short)
 debian_number=$(lsb_release --release --short)
-pkg_version="10.11.6"
+pkg_version="10.11.7"
 version=$(echo "$pkg_version" | cut -d '-' -f 1)
 
-ffmpeg_pkg_version="7.1.3-1"
+ffmpeg_pkg_version="7.1.3-4"
 
 # "targetAbi" line in plugin's meta.json, to check for outdated plugins
 # Usually, it should be the major version of the Jellyfin release (e.g. Jellyfin 10.10.7 -> plugin_abi 10.10.0)

--- a/scripts/backup
+++ b/scripts/backup
@@ -4,7 +4,6 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# Keep this path for calling _common.sh inside the execution's context of backup and restore scripts
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
@@ -14,19 +13,33 @@ ynh_print_info "Declaring files to be backed up..."
 # BACKUP THE APP MAIN DIR
 #=================================================
 
-ynh_backup "$data_path"
-ynh_backup "$config_path"
-ynh_backup "/etc/default/jellyfin" || true
+ynh_backup "$install_dir"
 
 #=================================================
-# SYSTEM CONFIGURATION
+# BACKUP THE DATA DIR
 #=================================================
 
+ynh_backup "$data_dir"
+
+#=================================================
+# BACKUP SYSTEM CONFIGURATION
+#=================================================
+
+# Backup the NGINX configuration
 ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 
+# Backup the systemd service unit
+ynh_backup "/etc/systemd/system/$app.service"
+
+# Backup the logrotate configuration
 ynh_backup "/etc/logrotate.d/$app"
 
-ynh_backup "/etc/systemd/system/jellyfin.service.d" || true
+#=================================================
+# BACKUP VARIOUS FILES
+#=================================================
+
+# NB: /var/log is not backuped during safety-backup-before-upgrades, same as $data_dir
+ynh_backup "/var/log/$app/"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -12,7 +12,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression "Stopping $app's systemd service..."
 
-ynh_systemctl --service="$app" --action="stop" --log_path="systemd" --timeout=15
+ynh_systemctl --service="$app" --action="stop" --timeout=15
 
 #=================================================
 # MODIFY URL IN NGINX CONF
@@ -40,7 +40,7 @@ fi
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service="$app" --action="start" --log_path="systemd" --timeout=15
+ynh_systemctl --service="$app" --action="start" --timeout=15
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -8,12 +8,9 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
-# CREATE DIRECTORIES
+# INITIALIZE AND STORE SETTINGS
 #=================================================
 
-if [ -d "$config_path" ]; then
-	ynh_die "There is already a directory: $config_path "
-fi
 ynh_app_setting_set --key=config_path --value="$config_path"
 
 #=================================================
@@ -27,22 +24,51 @@ if getent group render && ! id -Gn "$app" | grep -qw "\brender\b" >/dev/null; th
 fi
 
 #=================================================
-# INSTALL PACKAGES
+# DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
-ynh_script_progression "Installing packages..."
+ynh_script_progression "Setting up source files..."
 
 install_jellyfin_packages
+
+# Create necessary directories
+mkdir -p "$install_dir/config"
+
+#=================================================
+# INIT DB
+#=================================================
+ynh_script_progression "Initialize database..."
+
+# Use logrotate to manage application logfile(s)
+mkdir -p "/var/log/$app"
+touch "/var/log/$app/$app.log"
+ynh_config_add_logrotate
+
+# Jellyfin has to be started once to create the database before we can change the conf files
+# We already install the network.xml file because it works with it and it’s needed to not have a port conflict while running the command that follows
+# While running the command, we don’t indicate the path to the config dir, so it will assume to be at $data_dir/config
+mkdir -p "$data_dir/config"
+ynh_config_add --template="network.xml" --destination="$data_dir/config/network.xml"
+
+$install_dir/jellyfin/jellyfin -d $data_dir > "/var/log/$app/$app.log" 2>&1 &
+
+# Wait for previous command to have operated (database creation shouldn’t take to much time (about 10 seconds on my tests))
+ynh_script_progression "Waiting for Jellyfin to finish to create database..."
+sleep 30
+
+# Terminate the command because it won’t stop by itself. It should be safe as we watched the logs until the database was entirely migrated
+pkill -f "$install_dir/jellyfin/jellyfin" || true
+
+chown -R $app:$app "$install_dir"
+chown -R $app:$app "$data_dir"
+
+ynh_safe_rm $data_dir/config
 
 #=================================================
 # ADD A CONFIGURATION
 #=================================================
-ynh_print_info "Waiting 30s to let Jellyfin fully start a first time..."
-sleep 30
-
 ynh_script_progression "Adding $app's configuration..."
 
-ynh_systemctl --service="$app" --action="stop" --log_path="systemd" --timeout=15
-
+ynh_config_add --template=".env" --destination="$install_dir/.env"
 ynh_config_add --template="system.xml" --destination="$config_path/system.xml"
 ynh_config_add --template="network.xml" --destination="$config_path/network.xml"
 ynh_config_add --template="logging.json" --destination="$config_path/logging.json"
@@ -52,10 +78,10 @@ ynh_config_add --template="logging.json" --destination="$config_path/logging.jso
 #=================================================
 ynh_script_progression "Installing LDAP plugin..."
 
-ynh_setup_source --dest_dir="/var/lib/jellyfin/plugins/LDAP Authentication" --source_id=plugin_ldap
+ynh_setup_source --dest_dir="$data_dir/plugins/LDAP Authentication" --source_id=plugin_ldap
 
-mkdir -p /var/lib/jellyfin/plugins/configurations/
-ynh_config_add --template="LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
+mkdir -p $data_dir/plugins/configurations/
+ynh_config_add --template="LDAP-Auth.xml" --destination="$data_dir/plugins/configurations/LDAP-Auth.xml"
 
 #=================================================
 # SECURE FILES AND DIRECTORIES
@@ -63,8 +89,8 @@ ynh_config_add --template="LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugi
 ynh_script_progression "Securing files and directories..."
 
 # Set permissions to app files
-chown -R "$app:" "$data_path"
-chown -R "$app:" "$config_path"
+chown -R "$app:" "$data_dir"
+chown -R "$app:" "$install_dir"
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION
@@ -78,6 +104,16 @@ ynh_multimedia_build_main_dir
 ynh_multimedia_addaccess "$app"
 
 #=================================================
+# SETUP SYSTEMD
+#=================================================
+ynh_script_progression "Setting up systemd..."
+
+# Create a dedicated systemd config
+ynh_config_add_systemd
+
+yunohost service add "${app}" --description="Jellyfin media center" --log="/var/log/${app}/${app}.log"
+
+#=================================================
 # SYSTEM CONFIGURATION
 #=================================================
 ynh_script_progression "Adding system configurations related to $app..."
@@ -85,20 +121,13 @@ ynh_script_progression "Adding system configurations related to $app..."
 # Create a dedicated NGINX config using the conf/nginx.conf template
 ynh_config_add_nginx
 
-ynh_config_add --template="systemd.service" --destination="/etc/systemd/system/jellyfin.service.d/baseurl.service.conf"
-systemctl daemon-reload
-yunohost service add "$app" --description="Jellyfin media center"
-
-# Use logrotate to manage application logfile(s)
-ynh_config_add_logrotate
-
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
 # Start a systemd service
-ynh_systemctl --service="$app" --action="start" --log_path="systemd" --timeout=15
+ynh_systemctl --service="$app" --action="start" --timeout=15
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/remove
+++ b/scripts/remove
@@ -8,27 +8,19 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
-# REMOVE SYSTEM CONFIGURATIONS
+# REMOVE SYSTEM CONFIGURATION
 #=================================================
 ynh_script_progression "Removing system configurations related to $app..."
 
-# Remove the service from the list of services known by YunoHost (added from `yunohost service add`)
-if ynh_hide_warnings yunohost service status "$app" >/dev/null; then
-	yunohost service remove "$app"
-fi
-
 ynh_config_remove_logrotate
 
+# Remove the service from the list of services known by YunoHost (added from `yunohost service add`)
+if ynh_hide_warnings yunohost service status "$app" >/dev/null; then
+    yunohost service remove "$app"
+fi
+ynh_config_remove_systemd
+
 ynh_config_remove_nginx
-
-#=================================================
-# REMOVE VARIOUS FILES
-#=================================================
-ynh_script_progression "Removing various files..."
-
-ynh_safe_rm "$config_path"
-ynh_safe_rm "/etc/systemd/system/jellyfin.service.d"
-ynh_safe_rm "/etc/sudoers.d/jellyfin-sudoers"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -4,7 +4,6 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# Keep this path for calling _common.sh inside the execution's context of backup and restore scripts
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
@@ -24,27 +23,14 @@ fi
 #=================================================
 ynh_script_progression "Restoring the app main directory..."
 
-ynh_restore "$data_path"
-ynh_restore "$config_path"
-ynh_restore "/etc/default/jellyfin" || true
+ynh_restore "$install_dir"
 
 #=================================================
-# REINSTALL PACKAGES
+# RESTORE THE DATA DIRECTORY
 #=================================================
-ynh_script_progression "Reinstalling packages..."
+ynh_script_progression "Restoring the data directory..."
 
-#ynh_systemctl --service="$app" --action="mask"
-install_jellyfin_packages
-#ynh_systemctl --service="$app" --action="unmask"
-
-#=================================================
-# RESTORE USER RIGHTS
-#=================================================
-ynh_script_progression "Restoring user rights..."
-
-# Restore permissions on app files
-chown -R "$app:" "$data_path"
-chown -R "$app:" "$config_path"
+ynh_restore "$data_dir"
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION
@@ -58,24 +44,33 @@ ynh_multimedia_build_main_dir
 ynh_multimedia_addaccess "$app"
 
 #=================================================
-# RESTORE SYSTEM CONFIGURATIONS
+# RESTORE SYSTEM CONFIGURATION
 #=================================================
 ynh_script_progression "Restoring system configurations related to $app..."
 
 ynh_restore "/etc/nginx/conf.d/$domain.d/$app.conf"
 
-ynh_restore "/etc/systemd/system/jellyfin.service.d" || true
-systemctl enable jellyfin.service --quiet
-yunohost service add "$app" --description="Jellyfin media center"
+ynh_restore "/etc/systemd/system/$app.service"
+systemctl enable "$app.service" --quiet
+
+yunohost service add "${app}" --description="Jellyfin media center" --log="/var/log/${app}/${app}.log"
 
 ynh_restore "/etc/logrotate.d/$app"
+
+#=================================================
+# RESTORE VARIOUS FILES
+#=================================================
+
+ynh_restore "/var/log/$app/"
+chown -R $app:$app "/var/log/$app/"
+chmod 750 "/var/log/$app/"
 
 #=================================================
 # RELOAD NGINX AND PHP-FPM OR THE APP SERVICE
 #=================================================
 ynh_script_progression "Reloading NGINX web server and $app's service..."
 
-ynh_systemctl --service="$app" --action="start" --log_path="systemd" --timeout=15
+ynh_systemctl --service="$app" --action="start" --timeout=15
 
 ynh_systemctl --service=nginx --action=reload
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -14,12 +14,51 @@ if ynh_app_upgrading_from_version_before 10.10.7~ynh1; then
         \nOnce done you can upgrade to the latest version."
 fi
 
+
 #=================================================
 # STOP SYSTEMD SERVICE
 #=================================================
 ynh_script_progression "Stopping $app's systemd service..."
 
 ynh_systemctl --service="$app" --action="stop" --log_path="systemd" --timeout=15
+
+if ynh_app_upgrading_from_version_before 10.11.6~ynh2; then
+
+    mkdir -p $install_dir/config
+    mkdir -p $install_dir/cache
+
+    cp -rf /var/www/jellyfin/* "$data_dir"
+	cp -rf /etc/$app/* "$install_dir/config"
+    cp -rf /var/cache/$app/* "$install_dir/cache"
+
+    ynh_safe_rm "/etc/$app/"
+    ynh_safe_rm "/etc/default/jellyfin"
+    ynh_safe_rm "/etc/systemd/system/jellyfin.service.d"
+    ynh_safe_rm "/etc/sudoers.d/jellyfin-sudoers"
+    ynh_safe_rm "/var/lib/$app"
+    ynh_safe_rm "/var/cache/$app"
+
+	ynh_safe_rm "/var/www/jellyfin/data"
+	ynh_safe_rm "/var/www/jellyfin/metadata"
+	ynh_safe_rm "/var/www/jellyfin/plugins"
+	ynh_safe_rm "/var/www/jellyfin/root"
+	ynh_safe_rm "/var/www/jellyfin/'Subtitle Edit'"
+
+    config_path="$install_dir/config"
+    log_path="/var/log/$app"
+    cache_path="$install_dir/cache"
+    ynh_app_setting_set --key=config_path --value="$config_path"
+
+	ynh_replace --match="<EncoderAppPathDisplay>/usr/lib/jellyfin-ffmpeg/ffmpeg</EncoderAppPathDisplay>" \
+	            --replace="<EncoderAppPathDisplay>$install_dir/ffmpeg/ffmpeg</EncoderAppPathDisplay>" \
+	            --file="$install_dir/config/encoding.xml"
+
+	chown -R $app:$app "$data_dir"
+	chown -R $app:$app "$install_dir"
+
+	# Remove old systemd config
+	ynh_config_remove_systemd
+fi
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -31,27 +70,17 @@ if getent group render && ! id -Gn "$app" | grep -qw "\brender\b" >/dev/null; th
 	adduser "$app" render
 fi
 
-# If path keys do not exist, create them
-# If config_path is mixed up with install_dir, fix them
-if [ -z "$config_path" ] || [[ $config_path = "/var/lib/jellyfin" ]]; then
-	config_path=/etc/jellyfin
-	ynh_app_setting_set --key=config_path --value=$config_path
-fi
-
 ynh_app_setting_delete --key=is_public
-
 
 if [ ! -f "/etc/logrotate.d/$app" ]; then
 	# Fix possibly missing file due to buggy restore:
 	ynh_config_add_logrotate
 fi
 
-sqlite3 "/var/lib/jellyfin/data/library.db" ".tables"
-
 if ynh_app_upgrading_from_version_before 10.11.5~ynh1
 then
 	# Create UserDatas table before the migration // Thanks to https://github.com/getumbrel/umbrel-apps/pull/3872/changes/502e93dd57bd34e2899edb9ffd5dac1a7dbcbb89
-	sqlite3 "/var/lib/jellyfin/data/library.db" "
+	sqlite3 "$data_dir/data/library.db" "
 	BEGIN TRANSACTION;
 	CREATE TABLE IF NOT EXISTS UserDatas (
     	key TEXT NOT NULL,
@@ -70,20 +99,61 @@ then
 	"
 fi
 
-sqlite3 "/var/lib/jellyfin/data/library.db" ".tables"
-
 #=================================================
 # REMOVE OLD FILES
 #=================================================
-# Remove /var/lib/jellyfin/plugins-backup to mitigate a failed upgrade because a plugin is already there since an old upgrade.
+# Remove $data_dir/plugins-backup to mitigate a failed upgrade because a plugin is already there since an old upgrade (see below).
 # If it’s still there, it’s likely that the admin didn’t use this version of the plugin anymore.
-ynh_script_progression "Removing /var/lib/jellyfin/plugins-backup directory..."
-ynh_safe_rm "/var/lib/jellyfin/plugins-backup"
+ynh_script_progression "Removing $data_dir/plugins-backup directory..."
+ynh_safe_rm "$data_dir/plugins-backup"
+
+#=================================================
+# ENSURE NO OLD/INCOMPATIBLE PLUGINS ARE LEFT
+#=================================================
+shopt -s nullglob
+mkdir -p $data_dir/plugins-backup
+
+if [ -d $data_dir/plugins ]; then
+	for directory in $data_dir/plugins/*; do
+		name="$(basename "$directory")"
+		if [[ "$name" = "configurations" ]]; then
+			# Keep plugin config
+			continue
+		fi
+
+		if [ ! -f "$directory"/meta.json ]; then
+			ynh_print_warn "Jellyfin plugin '$name' looks legacy (missing meta.json). Moving to $data_dir/plugins-backup."
+			mv "$directory" $data_dir/plugins-backup/
+		fi
+
+		# Jellyfin doesn't refuse to start with old plugins. It just does weird
+		# things such as https://github.com/jellyfin/jellyfin-plugin-ldapauth/issues/161
+		# As a precaution, move older ABI plugins to another folder so things don't break
+		abi="$(jq -r '.targetAbi' "$directory/meta.json")"
+
+		if dpkg --compare-versions "$abi" lt "$plugin_abi"; then
+			ynh_print_warn "Jellyfin plugin '$name' ABI $abi is lower than expected $plugin_abi. Moving to $data_dir/plugins-backup."
+			mv "$directory" $data_dir/plugins-backup/
+		fi
+	done
+fi
+
+#=================================================
+# INSTALL LDAP PLUGIN
+#=================================================
+ynh_script_progression "Installing LDAP plugin..."
+
+ynh_setup_source --dest_dir="$data_dir/plugins/LDAP Authentication" --source_id=plugin_ldap --full_replace
+
+mkdir -p $data_dir/plugins/configurations/
+ynh_config_add --template="LDAP-Auth.xml" --destination="$data_dir/plugins/configurations/LDAP-Auth.xml"
+
+chown -R "$app:" "$data_dir"
 
 #=================================================
 # UPGRADE PACKAGES
 #=================================================
-ynh_script_progression "Upgrading packages..."
+ynh_script_progression "Upgrading source files..."
 
 # Backup the configuration files to prevent yunohost to see a manual edit
 bakdir=$(mktemp -d)
@@ -91,9 +161,7 @@ for name in system.xml network.xml logging.json; do
 	cp "$config_path/$name" "$bakdir/$name"
 done
 
-#ynh_systemctl --service="$app" --action="mask"
-install_jellyfin_packages
-#ynh_systemctl --service="$app" --action="unmask"
+upgrade_jellyfin_packages
 
 #=================================================
 # UPDATE A CONFIG FILE
@@ -106,56 +174,17 @@ for name in system.xml network.xml logging.json; do
 done
 ynh_safe_rm "$bakdir"
 
+ynh_config_add --template=".env" --destination="$install_dir/.env"
 ynh_config_add --template="network.xml" --destination="$config_path/network.xml"
 ynh_config_add --template="logging.json" --destination="$config_path/logging.json"
-
-#=================================================
-# ENSURE NO OLD/INCOMPATIBLE PLUGINS ARE LEFT
-#=================================================
-shopt -s nullglob
-mkdir -p /var/lib/jellyfin/plugins-backup
-
-if [ -d /var/lib/jellyfin/plugins ]; then
-	for directory in /var/lib/jellyfin/plugins/*; do
-		name="$(basename "$directory")"
-		if [[ "$name" = "configurations" ]]; then
-			# Keep plugin config
-			continue
-		fi
-
-		if [ ! -f "$directory"/meta.json ]; then
-			ynh_print_warn "Jellyfin plugin '$name' looks legacy (missing meta.json). Moving to /var/lib/jellyfin/plugins-backup."
-			mv "$directory" /var/lib/jellyfin/plugins-backup/
-		fi
-
-		# Jellyfin doesn't refuse to start with old plugins. It just does weird
-		# things such as https://github.com/jellyfin/jellyfin-plugin-ldapauth/issues/161
-		# As a precaution, move older ABI plugins to another folder so things don't break
-		abi="$(jq -r '.targetAbi' "$directory/meta.json")"
-
-		if dpkg --compare-versions "$abi" lt "$plugin_abi"; then
-			ynh_print_warn "Jellyfin plugin '$name' ABI $abi is lower than expected $plugin_abi. Moving to /var/lib/jellyfin/plugins-backup."
-			mv "$directory" /var/lib/jellyfin/plugins-backup/
-		fi
-	done
-fi
-
-#=================================================
-# INSTALL LDAP PLUGIN
-#=================================================
-ynh_script_progression "Installing LDAP plugin..."
-
-ynh_setup_source --full_replace --dest_dir="/var/lib/jellyfin/plugins/LDAP Authentication" --source_id=plugin_ldap
-mkdir -p /var/lib/jellyfin/plugins/configurations/
-ynh_config_add --template="LDAP-Auth.xml" --destination="/var/lib/jellyfin/plugins/configurations/LDAP-Auth.xml"
 
 #=================================================
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
 # Set permissions on app files
-chown -R "$app:" "$data_path"
-chown -R "$app:" "$config_path"
+chown -R "$app:" "$data_dir"
+chown -R "$app:" "$install_dir"
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION
@@ -169,6 +198,16 @@ ynh_multimedia_build_main_dir
 ynh_multimedia_addaccess "$app"
 
 #=================================================
+# SETUP SYSTEMD
+#=================================================
+ynh_script_progression "Setting up systemd..."
+
+# Create a dedicated systemd config
+ynh_config_add_systemd
+
+yunohost service add "${app}" --description="Jellyfin media center" --log="/var/log/${app}/${app}.log"
+
+#=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
 #=================================================
 ynh_script_progression "Upgrading system configurations related to $app..."
@@ -176,20 +215,15 @@ ynh_script_progression "Upgrading system configurations related to $app..."
 # Create a dedicated NGINX config
 ynh_config_add_nginx
 
-ynh_config_add --template="systemd.service" --destination="/etc/systemd/system/jellyfin.service.d/baseurl.service.conf"
-systemctl daemon-reload
-
 # Use logrotate to manage app-specific logfile(s)
 ynh_config_add_logrotate
-
-yunohost service add "$app" --description="Jellyfin media center"
 
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service="$app" --action="start" --log_path="systemd" --timeout=15
+ynh_systemctl --service="$app" --action="start" --timeout=15
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,7 +22,7 @@ ynh_script_progression "Stopping $app's systemd service..."
 
 ynh_systemctl --service="$app" --action="stop" --log_path="systemd" --timeout=15
 
-if ynh_app_upgrading_from_version_before 10.11.6~ynh2; then
+if ynh_app_upgrading_from_version_before 10.11.7~ynh1; then
 
     mkdir -p $install_dir/config
     mkdir -p $install_dir/cache


### PR DESCRIPTION
Same as https://github.com/YunoHost-Apps/jellyfin_ynh/pull/207 but I messed it up with git…

- Fixes https://github.com/YunoHost-Apps/jellyfin_ynh/issues/191
- Fixes https://github.com/YunoHost-Apps/jellyfin_ynh/issues/189
- Fixes https://github.com/YunoHost-Apps/jellyfin_ynh/issues/208
- Fixes https://github.com/YunoHost-Apps/jellyfin_ynh/issues/220
- It’s now possible to have `multi_instance` (easier to test pr when the test server is not available)
- `yunohost app shell jellyfin` works

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
