### PR TITLE
Upgrade to v10.11.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Media System that manage and stream your media
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://jellyfin.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://demo.jellyfin.org/stable/web/index.html)
-[![Version: 10.11.6~ynh1](https://img.shields.io/badge/Version-10.11.6~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
+[![Version: 10.11.7~ynh1](https://img.shields.io/badge/Version-10.11.7~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/jellyfin/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/jellyfin"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jellyfin"
 description.en = "Media System that manage and stream your media"
 description.fr = "Système multimédia qui gère et diffuse vos médias"
 
-version = "10.11.6~ynh1"
+version = "10.11.7~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -57,10 +57,10 @@ ram.runtime = "100M"
 [resources]
 
     [resources.sources.server_bookworm]
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/arm64/jellyfin-server_10.11.6+deb12_arm64.deb"
-    arm64.sha256 = "af9ded4622f228436f2ab28b0dc05b0b15f30fe13098844e93ed489d5a524cc4"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-server_10.11.6+deb12_amd64.deb"
-    amd64.sha256 = "bdf37bb8118ad37c0d7b2609c7697c1a10dd0c7267444c1fd81c3dc138a4d360"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.7/arm64/jellyfin-server_10.11.7+deb12_arm64.deb"
+    arm64.sha256 = "34e0b19b07fafb80bda1d6d4f65251ce46c1d6900002c1f67a55939cbb083045"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.7/amd64/jellyfin-server_10.11.7+deb12_amd64.deb"
+    amd64.sha256 = "2d01decd4be43819b5484010a1bec7fc82f009a1961f359f288d5aa458538781"
 
     format = "whatever"
     extract = false
@@ -79,10 +79,10 @@ ram.runtime = "100M"
     prefetch = false
 
     [resources.sources.server_trixie]
-    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/arm64/jellyfin-server_10.11.6+deb13_arm64.deb"
-    arm64.sha256 = "7ddbb98426a3c752a9cb0c8b3b959ab070d20a75c49067360b3ea9187c5a8c3f"
-    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-server_10.11.6+deb13_amd64.deb"
-    amd64.sha256 = "5d84f65a61185bf65da3f2bef56070a4609fbc9470794375b9bd6c5de749a5cb"
+    arm64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.7/arm64/jellyfin-server_10.11.7+deb13_arm64.deb"
+    arm64.sha256 = "378d0899483ac070fd7c79ab1383b9130619de0716c003620d34b1185db89d7a"
+    amd64.url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.7/amd64/jellyfin-server_10.11.7+deb13_amd64.deb"
+    amd64.sha256 = "7649fcefff0f2976f395b1b5f15c7bf641ebb4f6ba2b082df7feaa39f6c7c53e"
 
     format = "whatever"
     extract = false
@@ -101,8 +101,8 @@ ram.runtime = "100M"
     prefetch = false
 
     [resources.sources.web_bookworm]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-web_10.11.6+deb12_all.deb"
-    sha256 = "d0d917002423209e529140200ef6eefffe1d22f749a17433c13cea01f248d212"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.7/amd64/jellyfin-web_10.11.7+deb12_all.deb"
+    sha256 = "9644a9358219918f11aa2a1ab199901d07288d323c67da84bc310630de5a8358"
 
     format = "whatever"
     extract = false
@@ -119,8 +119,8 @@ ram.runtime = "100M"
     prefetch = false
 
     [resources.sources.web_trixie]
-    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.6/amd64/jellyfin-web_10.11.6+deb13_all.deb"
-    sha256 = "945365c42db30dc620aa977b484d6cda404367cd0b6888549d2a6513825d949b"
+    url = "https://repo.jellyfin.org/files/server/debian/stable/v10.11.7/amd64/jellyfin-web_10.11.7+deb13_all.deb"
+    sha256 = "e94f6d75dc5fdabf39fa34e61e4691ef007e3b446118204fd6342702d293bca1"
 
     format = "whatever"
     extract = false
@@ -137,20 +137,20 @@ ram.runtime = "100M"
     prefetch = false
 
     [resources.sources.ffmpeg_bookworm]
-    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/arm64/jellyfin-ffmpeg7_7.1.3-1-bookworm_arm64.deb"
-    arm64.sha256 = "c1f069bae4f72ea401a2005847ebd019fd91738d2a443563a8d992ce29a18ee8"
-    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/amd64/jellyfin-ffmpeg7_7.1.3-1-bookworm_amd64.deb"
-    amd64.sha256 = "ee2fd205c86c630ed15c91c534adc33df7ce09a35bef5f42fd1ee119d26728ee"
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-4/arm64/jellyfin-ffmpeg7_7.1.3-4-bookworm_arm64.deb"
+    arm64.sha256 = "e89e3fb24e9649085d10ab43a210ab0bb3888d4eb4e71b97bbfbf88d661f47ac"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-4/amd64/jellyfin-ffmpeg7_7.1.3-4-bookworm_amd64.deb"
+    amd64.sha256 = "053ba722def54de986db55c8469df1506bdc9b6af18bc86d114b5b16ec412459"
 
     format = "whatever"
     extract = false
     rename = "jellyfin-ffmpeg7.deb"
 
     [resources.sources.ffmpeg_trixie]
-    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/arm64/jellyfin-ffmpeg7_7.1.3-1-trixie_arm64.deb"
-    arm64.sha256 = "ff8a8b5aa622272c044495c95a01f97858f09df743f667d4640b3882bb795f8c"
-    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-1/amd64/jellyfin-ffmpeg7_7.1.3-1-trixie_amd64.deb"
-    amd64.sha256 = "5b97d8aa2b7a219df3723c5dda481a3cda42b892ca0e6385f899e25a7448255b"
+    arm64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-4/arm64/jellyfin-ffmpeg7_7.1.3-4-trixie_arm64.deb"
+    arm64.sha256 = "784a062c434b59e57857ed9085b99bd4f54ff32d4ef649379af05ba416fa518d"
+    amd64.url = "https://repo.jellyfin.org/files/ffmpeg/debian/7.x/7.1.3-4/amd64/jellyfin-ffmpeg7_7.1.3-4-trixie_amd64.deb"
+    amd64.sha256 = "870c89dd4d3e84a120cf1955308411bb53356e14641532bf60cf8084bf84f223"
 
     format = "whatever"
     extract = false


### PR DESCRIPTION
> **WARNING:** This release contains several **extremely important security fixes**. These vulnerabilities will be disclosed in **14 days** as per our security policy. Users of **all versions prior to 10.11.7 are advised to upgrade immediately**.

https://github.com/jellyfin/jellyfin/releases/tag/v10.11.7

In this PR, I simply updated resources in the manifest that could be updated and their respective sha sum, i.e.:
- server_bookworm
- server_trixie
- web_bookwork
- web_trixie
- ffmpeg_bookworm
- ffmpeg_trixie

But I did nothing for the "archive" entries whose existing URLs lead to 404, and which do not seem used in the stripts. Not sure whether they serve a purpose or whether they could be removed:
- server_archive_bookworm
- server_archive_trixie
- web_archive_bookworm
- web_archive_trixie

For the remaining resources, they are already at their latest available version.